### PR TITLE
Middleware user error

### DIFF
--- a/src/reversion/middleware.py
+++ b/src/reversion/middleware.py
@@ -11,7 +11,7 @@ class RevisionMiddleware(object):
     def process_request(self, request):
         """Starts a new revision."""
         reversion.revision.start()
-        if request.user.is_authenticated():
+        if hasattr(request, 'user') and request.user.is_authenticated():
             reversion.revision.user = request.user
         
     def process_response(self, request, response):


### PR DESCRIPTION
I ran into a problem activating reversion for a site that does not define any users. RevisionMiddleware assumes that the request will have a user attribute, which leads to an AttributeError in my case. This patch simply adds a hasattr() test to deal with the case where user is not defined.
