### PR TITLE
Delete object on revision revert

### DIFF
--- a/src/reversion/models.py
+++ b/src/reversion/models.py
@@ -51,6 +51,9 @@ class Revision(models.Model):
             current_revision_dict = reversion.revision.follow_relationships(old_revision_dict)
             # Delete objects that are no longer in the current revision.
             for current_object in current_revision_dict:
+                if current_revision_dict[current_object] == VERSION_DELETE:
+                    current_object.delete()
+                    continue
                 if not current_object in old_revision_dict:
                     current_object.delete()
             


### PR DESCRIPTION
Hi Etianen,
Here's my use case about the change:

Object A has a set of related objects, when A gets saved with set = [] existing set objects are marked as deleted in the revision.
I revert to prev revision and then I have the set back, fine.
I revert "forward" and I expect to have an empty set which was not happening.

With this change deleted objects are then deleted during on revision.revert(delete= True).

Hope it helps :)

Tommaso
