### PR TITLE
Fix excluded FileFields

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -182,7 +182,7 @@ class VersionAdmin(admin.ModelAdmin):
                 new_object = self.save_form(request, form, change=True)
                 # HACK: If the value of a file field is None, remove the file from the model.
                 for field in new_object._meta.fields:
-                    if isinstance(field, models.FileField) and form.cleaned_data[field.name] is None:
+                    if isinstance(field, models.FileField) and form.cleaned_data.get(field.name) is None:
                         setattr(new_object, field.name, None)
             else:
                 form_validated = False


### PR DESCRIPTION
Whenever a FileField was excluded from the admin form, reversion would
crash with KeyError, 'cause form.cleaned_data didn't have the field.
