### PR TITLE
Fix django version warning with multiple versions

### DIFF
--- a/src/reversion/__init__.py
+++ b/src/reversion/__init__.py
@@ -30,7 +30,7 @@ def check_django_version():
                 u"Please see https://github.com/etianen/django-reversion/wiki/Compatible-Django-Versions"
             ) % {
                 "reversion_version": format_version(VERSION),
-                "supported_django_version": format_version(SUPPORTED_DJANGO_VERSION),
+                "supported_django_version": ' or '.join(format_version(v) for v in SUPPORTED_DJANGO_VERSIONS),
                 "django_version": format_version(django.VERSION[:3]),
             }
         )


### PR DESCRIPTION
Otherwise I get exception when running under 1.4 Django:

NameError: global name 'SUPPORTED_DJANGO_VERSION' is not defined
