### PR TITLE
Use InlineModelAdmin rather than TabularInline and StackedInline

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -68,7 +68,13 @@ class VersionAdmin(admin.ModelAdmin):
             for inline in self.inlines:
                 inline_model = inline.model
                 self._autoregister(inline_model)
-                if issubclass(inline, options.InlineModelAdmin):
+                if issubclass(inline, GenericInlineModelAdmin):
+                    ct_field = inline.ct_field
+                    ct_fk_field = inline.ct_fk_field
+                    for field in self.model._meta.many_to_many:
+                        if isinstance(field, GenericRelation) and field.object_id_field_name == ct_fk_field and field.content_type_field_name == ct_field:
+                            inline_fields.append(field.name)
+                elif issubclass(inline, options.InlineModelAdmin):
                     fk_name = inline.fk_name
                     if not fk_name:
                         for field in inline_model._meta.fields:
@@ -76,12 +82,6 @@ class VersionAdmin(admin.ModelAdmin):
                                 fk_name = field.name
                     accessor = inline_model._meta.get_field(fk_name).rel.related_name or inline_model.__name__.lower() + "_set"
                     inline_fields.append(accessor)
-                elif issubclass(inline, GenericInlineModelAdmin):
-                    ct_field = inline.ct_field
-                    ct_fk_field = inline.ct_fk_field
-                    for field in self.model._meta.many_to_many:
-                        if isinstance(field, GenericRelation) and field.object_id_field_name == ct_fk_field and field.content_type_field_name == ct_field:
-                            inline_fields.append(field.name)
             self._autoregister(self.model, inline_fields)
 
     def _get_template_list(self, template_name):


### PR DESCRIPTION
TabularInline and StackedInline both inherit from InlineModelAdmin which is intended as the base class for inline model admins. When VersionAdmin initializes itself it only looks for subclasses of TabularInline and StackedInline instead of InlineModelAdmin.

This is causing armstrong/armstrong#29 because we inherit directly from InlineModelAdmin.
