### PR TITLE
InlineAdminFormSet has a different `__init__` in Django 1.4

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -286,8 +286,9 @@ class VersionAdmin(admin.ModelAdmin):
         for inline, formset in zip(self.get_inline_instances(request), formsets):
             fieldsets = list(inline.get_fieldsets(request, obj))
             readonly = list(inline.get_readonly_fields(request, obj))
+            prepopulated = inline.get_prepopulated_fields(request, obj)
             inline_admin_formset = helpers.InlineAdminFormSet(inline, formset,
-                fieldsets, readonly, model_admin=self)
+                fieldsets, prepopulated, readonly, model_admin=self)
             inline_admin_formsets.append(inline_admin_formset)
             media = media + inline_admin_formset.media
         # Generate the context.


### PR DESCRIPTION
It now takes a `prepopulated_fields` argument, accessible from `ModelAdmin.get_prepopulated_fields`.
