### PR TITLE
UnicodeEncodeError when generating diffs with non-ASCII content

### DIFF
--- a/src/reversion/helpers.py
+++ b/src/reversion/helpers.py
@@ -47,7 +47,7 @@ else:
         old_text = old_version.field_dict[field_name] or u""
         new_text = new_version.field_dict[field_name] or u""
         # Generate the patch.
-        diffs = dmp.diff_main(str(old_text), str(new_text))
+        diffs = dmp.diff_main(unicode(old_text), unicode(new_text))
         if cleanup == "semantic":
             dmp.diff_cleanupSemantic(diffs)
         elif cleanup == "efficiency":


### PR DESCRIPTION
Currently if I create a diff using `reversion.helpers.generate_patch_html` I get a UnicodeEncodeError if the old or new content contains non-ASCII characters. 

```
…
File "/Users/pb/.virtualenvs/fhpcontent/lib/python2.7/site-packages/reversion/helpers.py" in generate_patch_html
  80.         diffs = generate_diffs(old_version, new_version, field_name, cleanup)
File "/Users/pb/.virtualenvs/fhpcontent/lib/python2.7/site-packages/reversion/helpers.py" in generate_diffs
  50.         diffs = dmp.diff_main(str(old_text), str(new_text))

Exception Type: UnicodeEncodeError at /8/diff/27..28/
Exception Value: 'ascii' codec can't encode character u'\xdc' in position 49: ordinal not in range(128)
```

The attached commit uses `unicode()` instead of `str()` and fixes this bug.
