### PR TITLE
Skip test on admin integration if django.contrib.admin is not activated

### DIFF
--- a/src/reversion/tests.py
+++ b/src/reversion/tests.py
@@ -635,8 +635,6 @@ class RevisionMiddlewareTest(ReversionTestBase):
         self.assertEqual(Version.objects.count(), 0)
 
 
-@skipUnless('django.contrib.admin' in settings.INSTALLED_APPS,
-            "django.contrib.admin not activated")
 class VersionAdminTest(TestCase):
 
     urls = "reversion.tests"
@@ -651,10 +649,14 @@ class VersionAdminTest(TestCase):
         self.user.save()
         self.client.login(username="foo", password="bar")
 
+    @skipUnless('django.contrib.admin' in settings.INSTALLED_APPS,
+                "django.contrib.admin not activated")
     def testAutoRegisterWorks(self):
         self.assertTrue(reversion.is_registered(ChildTestAdminModel))
         self.assertTrue(reversion.is_registered(ParentTestAdminModel))
-        
+
+    @skipUnless('django.contrib.admin' in settings.INSTALLED_APPS,
+                "django.contrib.admin not activated")
     def testRevisionSavedOnPost(self):
         self.assertEqual(ChildTestAdminModel.objects.count(), 0)
         # Create an instance via the admin.


### PR DESCRIPTION
Hi Dave

Using reversion in my wikify project I receive and error:

```
Traceback (most recent call last):
  File "/tmp/django-wikify/env/local/lib/python2.7/site-packages/reversion/tests.py", line 661, in testRevisionSavedOnPost
...
DatabaseError: no such table: django_admin_log
```

This happens as I am not enabling `django.contrib.admin` in the test project.

I implemented a skip directive to skip admin tests in this context.
