### PR TITLE
(Issue #112) Patch: Retrieve the created revision

### DIFF
--- a/src/reversion/revisions.py
+++ b/src/reversion/revisions.py
@@ -280,7 +280,7 @@ class RevisionContext(object):
 
     """An individual context for a revision."""
 
-    def __init__(self, context_manager, manage_manually):
+    def __init__(self, context_manager, manage_manually=False):
         """Initializes the revision context."""
         self._context_manager = context_manager
         self._manage_manually = manage_manually


### PR DESCRIPTION
Hi. I have implemented a solution for Issue #112 that allows the created revisions to be retrieved directly from the RevisionContext.

Usage:

``` python
with reversion.create_revision() as revcontext:
    # do something
    pass
revisions = revcontext.result()
print revisions["default"].id
```

Thanks.
Simon
