### PR TITLE
Fixed issue #110 (testCreateInitialRevisions fails for with initial_data)

### DIFF
--- a/src/reversion/tests.py
+++ b/src/reversion/tests.py
@@ -507,11 +507,13 @@ class CreateInitialRevisionsTest(ReversionTestBase):
         self.assertEqual(Revision.objects.count(), 0)
         self.assertEqual(Version.objects.count(), 0)
         call_command("createinitialrevisions")
-        self.assertEqual(Revision.objects.count(), 4)
-        self.assertEqual(Version.objects.count(), 4)
+        revcount = Revision.objects.count()
+        vercount = Version.objects.count()
+        self.assertTrue(revcount > 4)
+        self.assertTrue(vercount > 4)
         call_command("createinitialrevisions")
-        self.assertEqual(Revision.objects.count(), 4)
-        self.assertEqual(Version.objects.count(), 4)
+        self.assertEqual(Revision.objects.count(), revcount)
+        self.assertEqual(Version.objects.count(), vercount)
         
     def testCreateInitialRevisionsSpecificApps(self):
         call_command("createinitialrevisions", "auth")


### PR DESCRIPTION
Fix for issue #110 (why won't github let me add pull-requests to an existing issue?).

It wasn't possible to retrieve the 'current' number of revision models, because they are all created within the call to createinitialrevisions. Instead I check that we end up with at least the number of initial revisions we were expecting.
