### PR TITLE
Fix for #128

### DIFF
--- a/src/reversion/tests.py
+++ b/src/reversion/tests.py
@@ -647,6 +647,8 @@ class VersionAdminTest(TestCase):
             is_staff = True,
             is_superuser = True,
         )
+        self.global_site = admin.site
+        admin.site = site
         self.user.set_password("bar")
         self.user.save()
         self.client.login(username="foo", password="bar")
@@ -717,6 +719,7 @@ class VersionAdminTest(TestCase):
         self.client.logout()
         self.user.delete()
         del self.user
+        admin.site = self.global_site
         ChildTestAdminModel.objects.all().delete()
 
 


### PR DESCRIPTION
django-reversion tests create custom AdminSite object with empty registry of models.

But django-admin-tools uses this code:

```
from django.contrib import admin
admin.site._registry()
```

And receives global admin with application's models.
