### PR TITLE
Fixed tests

### DIFF
--- a/src/reversion/tests.py
+++ b/src/reversion/tests.py
@@ -418,7 +418,6 @@ class MultiTableInheritanceApiTest(RevisionTestBase):
     
     def tearDown(self):
         super(MultiTableInheritanceApiTest, self).tearDown()
-        ReversionTestModel1Child.objects.all().delete()
         del self.testchild1
 
 


### PR DESCRIPTION
Currently `createinitialrevisions` registers all application's models, but teardown unregisters only some of them. This patchs unregisters all registered models in the test
