### PR TITLE
Suppress warning for django 1.4.1

### DIFF
--- a/src/reversion/__init__.py
+++ b/src/reversion/__init__.py
@@ -18,6 +18,7 @@ VERSION = __version__
 
 SUPPORTED_DJANGO_VERSIONS = (
     (1, 4, 0),
+    (1, 4, 1),
 )
 
 def check_django_version():


### PR DESCRIPTION
Not sure if you want to maintain explicit version checks or make it a bit more general so django-reversion only checks (major, minor).
