### PR TITLE
Added linebreaksbr filter in template

### DIFF
--- a/src/reversion/templates/reversion/object_history.html
+++ b/src/reversion/templates/reversion/object_history.html
@@ -27,7 +27,7 @@
                                         {% if action.revision.user.first_name %} ({{action.revision.user.first_name}} {{action.revision.user.last_name}}){% endif %}
                                     {% endif %}
                                 </td>
-                                <td>{{action.revision.comment|default:""}}</td>
+                                <td>{{action.revision.comment|linebreaksbr|default:""}}</td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
Hi,

just a small UI issue. I run into the issue that the reversion template object_history.html does not convert line breaks from textareas into <br>'s as you should do for a text field. Fixed that in this fork.

Thanks and take care.
stj
