### PR TITLE
Enabling django-1.5 Compatibility

### DIFF
--- a/src/reversion/templates/reversion/recover_form.html
+++ b/src/reversion/templates/reversion/recover_form.html
@@ -1,11 +1,12 @@
 {% extends "reversion/revision_form.html" %}
+{% load url from future %}
 {% load i18n %}
 
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
-        <a href="{% url admin:index %}">{% trans "Home" %}</a> &rsaquo;
-        <a href="{% url admin:app_list app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
+        <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
+        <a href="{% url 'admin:app_list' app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
         <a href="{{changelist_url}}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo;
         <a href="{{recoverlist_url}}">{% blocktrans with opts.verbose_name_plural as name %}Recover deleted {{name}}{% endblocktrans %}</a> &rsaquo;
         {{title}}

--- a/src/reversion/templates/reversion/recover_list.html
+++ b/src/reversion/templates/reversion/recover_list.html
@@ -1,11 +1,12 @@
 {% extends "admin/base_site.html" %}
+{% load url from future %}
 {% load i18n %}
 
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
-        <a href="{% url admin:index %}">{% trans 'Home' %}</a> &rsaquo; 
-        <a href="{% url admin:app_list app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
+        <a href="{% url 'admin:app_list' app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
         <a href="{{changelist_url}}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo; 
         {% blocktrans with opts.verbose_name_plural|escape as name %}Recover deleted {{name}}{% endblocktrans %}
     </div>

--- a/src/reversion/templates/reversion/revision_form.html
+++ b/src/reversion/templates/reversion/revision_form.html
@@ -1,11 +1,12 @@
 {% extends "admin/change_form.html" %}
+{% load url from future %}
 {% load i18n %}
 
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
-        <a href="{% url admin:index %}">{% trans "Home" %}</a> &rsaquo;
-        <a href="{% url admin:app_list app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
+        <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
+        <a href="{% url 'admin:app_list' app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
         <a href="{{changelist_url}}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo;
         <a href="{{change_url}}">{{original|truncatewords:"18"}}</a> &rsaquo;
         <a href="../">{% trans "History" %}</a> &rsaquo;


### PR DESCRIPTION
With the usage of {% load url from future %} and single quotes for url tags names in the templates django-reversion becomes compatible with both django-1.4 and django-1.5. 
