### PR TITLE
Fix for deprecation warnings on django 1.4.0

### DIFF
--- a/src/reversion/templates/reversion/recover_list.html
+++ b/src/reversion/templates/reversion/recover_list.html
@@ -1,11 +1,12 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
+{% load url from future %}
 
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
-        <a href="{% url admin:index %}">{% trans 'Home' %}</a> &rsaquo; 
-        <a href="{% url admin:app_list app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
+        <a href="{% url 'admin:app_list' app_label %}">{{app_label|capfirst|escape}}</a> &rsaquo; 
         <a href="{{changelist_url}}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo; 
         {% blocktrans with opts.verbose_name_plural|escape as name %}Recover deleted {{name}}{% endblocktrans %}
     </div>


### PR DESCRIPTION
We've been noticing deprecation warnings on django 1.4.0 about the url templatetag when running the reversion tests. These changes cause the deprecation warnings to disappear. I'm not sure if there is some module incompatibility in play, therefore here is the output of my pip freeze:

Django==1.4
Fabric==1.4.3
Jinja2==2.6
PIL==1.1.7
Reindent==0.1.1
SQLAlchemy==0.7.8
South==0.7.6
Tempita==0.5.1
Twisted==12.1.0
argparse==1.2.1
autopep8==0.7.3
beautifulsoup4==4.1.1
buildbot==0.8.6p1
buildbot-slave==0.8.6p1
chemfp==1.1b4
coverage==3.5.2
decorator==3.3.3
distribute==0.6.24
django-ajax-selects==1.2.5
django-appconf==0.5
django-auth-ldap==1.1.1
django-buildhost==0.0.1b0
django-compress==1.0.1
django-compressor==1.1.2
django-concurrency==0.1.4b1
django-dajax==0.9.2
django-dajaxice==0.5.1
django-extensions==0.9
django-geo==0.2.1b5
django-guardian==1.0.4
django-iadmin==0.1.8
django-mptt==0.5.4
django-object-log==0.7
django-reversion==1.6.2
-e git+http://github.com/saxix/django-site-maintenance.git@cf2b211ba1ce6aaae240a40275b83c013941a821#egg=django_site_maintenance-dev
django-tables2==0.11.0
-e git+http://github.com/toastdriven/django-tastypie.git@5397dec04fe83092a56ba14a843731f2aa08184d#egg=django_tastypie-dev
django-uuidfield==0.4.0
django-webcam==0.1.4b3
django-whatever==0.2.3
docutils==0.9.1
epydoc==3.0.1
factory-boy==1.1.5
flake8==1.4
foodnet==0.0.10a1
ipython==0.13
logilab-astng==0.24.0
logilab-common==0.58.1
mimeparse==0.1.3
mock==1.0b1
pep8==1.3.3
pep8ify==0.0.5
psycopg2==2.4.5
pyactiveresource==1.0.2
pycrypto==2.6
pyflakes==0.5.0
pylint==0.25.2
python-dateutil==1.5
python-ldap==2.4.10
pytz==2012d
selenium==2.25.0
simplejson==2.6.0
snakefood==1.4
sqlalchemy-migrate==0.7.2
ssh==1.7.14
uuid==1.30
wsgiref==0.1.2
zope.deprecation==4.0.0
zope.interface==4.0.1
