### PR TITLE
Fixed an incompatibilty with django-orm (at least)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('src/reversion')
+sys.path.insert(0, 'src/reversion')
 from distutils.core import setup
 from version import __version__
 


### PR DESCRIPTION
django-orm includes a version.py module: if you append reversion to the sys.path, setuptools takes the django-orm one. ATM i have django-reversion 3.0.0b3 :(
