### PR TITLE
Support for Django 1.4.2 (security release)

### DIFF
--- a/src/reversion/__init__.py
+++ b/src/reversion/__init__.py
@@ -19,6 +19,7 @@ VERSION = __version__
 SUPPORTED_DJANGO_VERSIONS = (
     (1, 4, 0),
     (1, 4, 1),
+    (1, 4, 2),
 )
 
 def check_django_version():


### PR DESCRIPTION
Django 1.4.2 was [released yesterday](https://www.djangoproject.com/weblog/2012/oct/17/security). This commit removes warning message about version compatibility.
