### PR TITLE
Allow injection of a db-specific optimised Version.object_id_int migration

### DIFF
--- a/src/reversion/migrations/0004_populate_object_id_int.py
+++ b/src/reversion/migrations/0004_populate_object_id_int.py
@@ -12,7 +12,7 @@ class Migration(DataMigration):
 
     def forwards(self, orm):
         "Write your forwards methods here."
-        for version in orm.Version.objects.all().iterator():
+        for version in orm.Version.objects.filter(object_id_int__isnull=True).iterator():
             try:
                 content_type = ContentType.objects.get_for_id(version.content_type_id)
             except AttributeError:


### PR DESCRIPTION
Migration `0004_populate_object_id_int` currently uses a queryset to process all records and update those referencing a model using an integer pk. This can take a very long time for large tables, but the only solution I could find requires using database-specific syntax in a raw query to apply the update.

Filtering only records where object_id_int is null would allow the injection of an external data migration between reversion's 0003 and 0004 (using `depends_on` and `needed_by` properties in the injected step) without further modifications to reversion's code base, and would still yield the same result in a normal migration.

Since values are not reset during backwards migrations, this also means those records will be  ignored after the first run. This shouldn't normally be an issue, but if you'd rather play safe just let me know. The "paranoid" version of the backwards migration would require checking that str(object_id_int) == object_id, but we can probably take this for granted and just bulk update.

Thank you.
Stefano
