### PR TITLE
Access to creation time of revision before it is written in to database

### DIFF
--- a/src/reversion/models.py
+++ b/src/reversion/models.py
@@ -64,8 +64,7 @@ class Revision(models.Model):
         default = "default",
     )
     
-    date_created = models.DateTimeField(auto_now_add=True,
-                                        verbose_name=_("date created"),
+    date_created = models.DateTimeField(verbose_name=_("date created"),
                                         help_text="The date and time this revision was created.")
     
     user = models.ForeignKey(User,


### PR DESCRIPTION
In our case, sorting of Documents(more than 10k) by creation and last modification time was a big performance issue. To get first 20 Documents sorted by last modification time, we used following query:

``` python
Document.objects.all()
                .order_by('-version_set__revision__date_created')
                .distinct()[:20]
```

As you see it is complicated and a costly query, specially for documents with many changes.

To solve this problem we added _created_ and _modified_ fields into a Document model. But it causes database inconsistency, because in many cases the creation time of a document is not equal to creation time of his first revision. Therefore we can not compare these fields.

In this pull request we can access to creation time of revision before it is written in to database.
The following two functions illustrates how it can be used:

``` python
def create_document(user, title, content):
    with reversion.create_revision():
        reversion.set_user(user)
        document = Document.objects.create(
            title=title,
            content=content,
            created=reversion.get_date_created(),
            last_modified=reversion.get_date_created(),
        )
    return document

def edit_document(user, document, title, content):
    with reversion.create_revision():
        reversion.set_user(user)
        document.title=title
        document.content=content
        document.last_modified=reversion.get_date_created()
        document.save()
```
