### PR TITLE
Add egg-info directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 dist
 build
 MANIFEST
+src/django_reversion.egg-info/


### PR DESCRIPTION
This change is for people who do `pip install -e .` at the application directory, and get an egg-info directory created there. 
