### PR TITLE
Changed code which handles swapped out auth.user model to prevent circular import

### DIFF
--- a/src/reversion/models.py
+++ b/src/reversion/models.py
@@ -3,15 +3,9 @@
 import warnings
 from functools import partial
 
-try:
-    from django.contrib.auth import get_user_model
-except ImportError: # django < 1.5
-    from django.contrib.auth.models import User
-else:
-    User = get_user_model()
-
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
+from django.conf import settings
 from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
@@ -60,6 +54,7 @@ class RevertError(Exception):
     """Exception thrown when something goes wrong with reverting a model."""
 
 
+UserModel = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 class Revision(models.Model):
     
     """A group of related object versions."""
@@ -74,7 +69,7 @@ class Revision(models.Model):
                                         verbose_name=_("date created"),
                                         help_text="The date and time this revision was created.")
     
-    user = models.ForeignKey(User,
+    user = models.ForeignKey(UserModel,
                              blank=True,
                              null=True,
                              verbose_name=_("user"),


### PR DESCRIPTION
At the previous approach you may get circular import error, if your custom User model is defined at the same file, at which you call `reversion.register()`. That is because register imports `reversion.models`, and those call `get_user_model()`, and this function import `models.py` of the application, which contains register call.

This change is backwards-compatible with django < 1.5, because before then there were no `settings.AUTH_USER_MODEL`, so UserModel becomes just 'auth.User', and using string in format "appname.ModelName" in ForeignKey is OK even for django 1.3: https://docs.djangoproject.com/en/1.3/ref/models/fields/#foreignkey
