### PR TITLE
Account for moved around objects in Django 1.6

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -3,7 +3,10 @@ from functools import partial
 
 from django import template
 from django.db import models, transaction, connection
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except:
+    from django.conf.urls.defaults import patterns, url
 from django.contrib import admin
 from django.contrib.admin import helpers, options
 from django.contrib.admin.util import unquote, quote


### PR DESCRIPTION
This small patch causes django-reversion to at least load up properly in Django 1.6.
