### PR TITLE
Exclude inline admins from being reverted when not followed.

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -26,6 +26,7 @@ from django.utils.formats import localize
 
 from reversion.models import Revision, Version, has_int_pk, VERSION_ADD, VERSION_CHANGE, VERSION_DELETE
 from reversion.revisions import default_revision_manager, RegistrationError
+import reversion
 
 
 class VersionAdmin(admin.ModelAdmin):
@@ -221,6 +222,12 @@ class VersionAdmin(admin.ModelAdmin):
     
     def _hack_inline_formset_initial(self, FormSet, formset, obj, version, revert, recover):
         """Hacks the given formset to contain the correct initial data."""
+
+        # if the FK this inline formset represents is not being followed, don't process data for it.
+        # see https://github.com/etianen/django-reversion/issues/222
+        if formset.rel_name not in reversion.get_adapter(self.model).follow:
+            return
+
         # Now we hack it to push in the data from the revision!
         initial = []
         related_versions = self.get_related_versions(obj, version, FormSet)


### PR DESCRIPTION
Fixes etianen/django-reversion#222

I put the check inside of _hack_inline_formset_initial so the logic would only have to be in one place.

I couldn't find a way to accurately test the actual reversion from the admin since what is submitted would have the delete value I specify, not the delete value reversion generated. I believe my method of checking the initial page load for the value of delete should work but if you have a better idea, please let me know.
