### PR TITLE
Fix for custom user model with db_table specified

### DIFF
--- a/src/reversion/migrations/0001_initial.py
+++ b/src/reversion/migrations/0001_initial.py
@@ -60,7 +60,7 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         "%s.%s" % (User._meta.app_label, User._meta.module_name): {
-            'Meta': {'object_name': User.__name__ },
+            'Meta': {'object_name': User.__name__, "db_table": "'%s'" % User._meta.db_table},
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),


### PR DESCRIPTION
We need to supply db_table in the initial migration
otherwise using a custom user model in conjunction
with Meta.db_table will prevent the initial migration
from running.
