### PR TITLE
Remove ordered_objects from admin context.

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -362,7 +362,6 @@ class VersionAdmin(admin.ModelAdmin):
                         "has_delete_permission": self.has_delete_permission(request, obj),
                         "has_file_field": True,
                         "has_absolute_url": False,
-                        "ordered_objects": opts.get_ordered_objects(),
                         "form_url": mark_safe(request.path),
                         "opts": opts,
                         "content_type_id": ContentType.objects.get_for_model(self.model).id,


### PR DESCRIPTION
Hi!

The true purpose of this pull-request is fix some django-1.6 incompatibility.

It removes get_ordered_objects call, because on django 1.6 this method does not exists and on django 1.5 it always return a empty list (https://github.com/django/django/blob/stable/1.5.x/django/db/models/options.py#L543)
Also, it seems not used by reversion but I'm not sure with this assertion!

With this change, django-reversion seems work properly with django-1.6beta1
