### PR TITLE
Show username and full name from custom user model, fix #244

### DIFF
--- a/src/reversion/templates/reversion/object_history.html
+++ b/src/reversion/templates/reversion/object_history.html
@@ -23,8 +23,8 @@
                                 <th scope="row"><a href="{{action.url}}">{{action.revision.date_created}}</a></th>
                                 <td>
                                     {% if action.revision.user %}
-                                        {{action.revision.user.username}}
-                                        {% if action.revision.user.first_name %} ({{action.revision.user.first_name}} {{action.revision.user.last_name}}){% endif %}
+                                        {{action.revision.user.get_username}}
+                                        {% if action.revision.user.get_full_name %} ({{action.revision.user.get_full_name}}){% endif %}
                                     {% endif %}
                                 </td>
                                 <td>{{action.revision.comment|linebreaksbr|default:""}}</td>


### PR DESCRIPTION
`get_username`  would support custom username field other than `username` (say `email` as username field)

Both `get_username` and `get_full_name` are documented since 1.5
