### PR TITLE
Fix bug in RevisionMiddleware exception handling

### DIFF
--- a/src/reversion/middleware.py
+++ b/src/reversion/middleware.py
@@ -27,7 +27,8 @@ class RevisionMiddleware(object):
         """Closes the revision."""
         # look to see if the session has been accessed before looking for user to stop Vary: Cookie
         if hasattr(request, 'session') and request.session.accessed \
-                and hasattr(request, "user") and request.user.is_authenticated():
+                and hasattr(request, "user") and request.user.is_authenticated() \
+                and revision_context_manager.is_active():
             revision_context_manager.set_user(request.user)
         self._close_revision(request)
         return response


### PR DESCRIPTION
Greetings Dave and others,

I was debugging an issue in another project that occurred when using the latest Git version of reversion but not any of the releases.  It appears that a commit 99a2871 (which allows proxy caching to be used with reversion) may be introducing a new exception after an exception has been thrown elsewhere, which can confuse debugging.  It's possible that this is related to issue #225.

I'm not very experienced with reversion, but I wanted to show a tweak that appeared to fix the problem on our end and see if it made sense.  Commit message copied below:

Recently the RevisionMiddleware was modified to avoid accessing
request.user unncessarily for caching purposes.  This works well
except in some cases it can obscure errors generated elsewhere in a
project.

The RevisionContextManager has "active" and "inactive" states.
If there is an exception handler elsewhere in the middleware stack
that generates a new HTTP response, the
RevisionMiddleware.process_exception() method will inactivate the
RevisionContextManager via _close_revision().  Then the HTTP response will
be provided to process_response().  If a user is logged in the middleware
will call RevisionContextManager.set_user(), which expects to be in the
active state, and throws an error ("no active revision for this thread").

To fix this, check if the RevisionContextManager is in the active state
before calling set_user.
