### PR TITLE
Update signals.rst

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -5,7 +5,7 @@ Signals sent by django-reversion
 
 django-reversion provides a number of custom signals that can be used to tie-in additional functionality to the version creation mechanism.
 
-**Important:** Don't connect to the pre_save or post_save signals of the Version or Revision models directly, use the signals outlined below instead. The pre_save and post_save signals are longer sent by the Version or Revision models since django-reversion 1.7.
+**Important:** Don't connect to the pre_save or post_save signals of the Version or Revision models directly, use the signals outlined below instead. The pre_save and post_save signals are no longer sent by the Version or Revision models since django-reversion 1.7.
 
 reversion.pre_revision_commit
 -----------------------------


### PR DESCRIPTION
Quick fix of typo in signal documentation.  The word "no" was missing.
