### PR TITLE
Add model name to proxy RegistrationError

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -58,8 +58,10 @@ class VersionAdmin(admin.ModelAdmin):
         """Registers a model with reversion, if required."""
         if model._meta.proxy:
             raise RegistrationError(
-                "Proxy models cannot be used with django-reversion, register the parent class instead: {model}".format(
+                "{model} is a proxy model, and cannot be used with django-reversion, register the parent class ({model_parent}) instead.".format(  # noqa
                     model=model.__name__,
+                    model_parent=', '.join(
+                        [x.__name__ for x in model._meta.parents.keys()])
                 ))
         if not self.revision_manager.is_registered(model):
             follow = follow or []

--- a/src/reversion/revisions.py
+++ b/src/reversion/revisions.py
@@ -373,8 +373,10 @@ class RevisionManager(object):
         # Prevent proxy models being registered.
         if model._meta.proxy:
             raise RegistrationError(
-                "Proxy models cannot be used with django-reversion, register the parent class instead: {model}".format(
+                "{model} is a proxy model, and cannot be used with django-reversion, register the parent class ({model_parent}) instead.".format(  # noqa
                     model=model.__name__,
+                    model_parent=', '.join(
+                        [x.__name__ for x in model._meta.parents.keys()])
                 ))
         # Perform any customization.
         if field_overrides:

--- a/src/reversion/tests.py
+++ b/src/reversion/tests.py
@@ -121,7 +121,7 @@ class RegistrationTest(TestCase):
         with self.assertRaises(RegistrationError) as cm:
             reversion.register(ReversionTestModel1Proxy)
         self.assertEqual(str(cm.exception),
-                         "Proxy models cannot be used with django-reversion, register the parent class instead: ReversionTestModel1Proxy")
+                         "ReversionTestModel1Proxy is a proxy model, and cannot be used with django-reversion, register the parent class (ReversionTestModel1) instead.")  # noqa
 
 
 class ReversionTestBase(TestCase):


### PR DESCRIPTION
This is helpful to find the proxy model in case of error.
