### PR TITLE
Fixes integration tests for RevisionMiddleware

### DIFF
--- a/src/reversion/tests.py
+++ b/src/reversion/tests.py
@@ -21,7 +21,7 @@ except ImportError: # django < 1.5
     from django.contrib.auth.models import User
 else:
     User = get_user_model()
-from django.utils.decorators import decorator_from_middleware
+from django.utils.decorators import decorator_from_middleware as django_decorator_from_middleware
 from django.http import HttpResponse
 from django.utils.unittest import skipUnless
 from django.utils.encoding import force_text, python_2_unicode_compatible
@@ -591,6 +591,43 @@ class CreateInitialRevisionsTest(ReversionTestBase):
 
 # Tests for reversion functionality that's tied to requests.        
 
+# RevisionMiddleware is tested by applying it as a decorator to various view
+# functions. Django's decorator_from_middleware() utility function does the
+# trick of converting a middleware class to a decorator. However, in projects
+# that include the middleware in the MIDDLEWARE_CLASSES setting, the wrapped
+# view function is processed twice by the middleware. When RevisionMiddleware
+# processes a function twice, an ImproperlyConfigured exception is raised.
+# Thus, using Django's definition of decorator_from_middleware() can prevent
+# reversion integration tests from passing in projects that include
+# RevisionMiddleware in MIDDLEWARE_CLASSES.
+#
+# To avoid this problem, we redefine decorator_from_middleware() to return a
+# decorator that does not reapply the middleware if it is in
+# MIDDLEWARE_CLASSES.  @decorator_from_middleware(RevisionMiddleware) is then
+# used to wrap almost all RevisionMiddleware test views. The only exception is
+# double_middleware_revision_view(), which needs to be doubly processed by
+# RevisionMiddleware.  This view is wrapped twice with
+# @django_decorator_from_middleware(RevisionMiddleware), where
+# django_decorator_from_middleware() is imported as Django's definition of
+# decorator_from_middleware().
+
+revision_middleware_django_decorator = django_decorator_from_middleware(RevisionMiddleware)
+
+def decorator_from_middleware(middleware_class):
+    """
+    This is a wrapper around django.utils.decorators.decorator_from_middleware
+    (imported as django_decorator_from_middleware). If the middleware class is
+    not loaded via MIDDLEWARE_CLASSES in the project settings, then the
+    middleware decorator is returned. However, if the middleware is already
+    loaded, then an identity decorator is returned instead, so that the
+    middleware does not process the view function twice.
+    """
+    middleware_path = "%s.%s" % (middleware_class.__module__,
+                                 middleware_class.__name__)
+    if middleware_path in settings.MIDDLEWARE_CLASSES:
+        return lambda view_func: view_func
+    return django_decorator_from_middleware(middleware_class)
+
 revision_middleware_decorator = decorator_from_middleware(RevisionMiddleware)
 
 # A dumb view that saves a revision.
@@ -630,8 +667,8 @@ def error_revision_view(request):
 
 
 # A dumb view that has two revision middlewares.
-@revision_middleware_decorator
-@revision_middleware_decorator
+@revision_middleware_django_decorator
+@revision_middleware_django_decorator
 def double_middleware_revision_view(request):
     raise Exception("Foo")
 


### PR DESCRIPTION
`RevisionMiddleware` is tested by applying it as a decorator to various view
functions. Django's `decorator_from_middleware()` utility function does the trick
of converting a middleware class to a decorator. However, in projects that
include the middleware in the `MIDDLEWARE_CLASSES` setting, the wrapped view
function is processed twice by the middleware. When `RevisionMiddleware`
processes a function twice, an `ImproperlyConfigured` exception is raised.  Thus,
use of Django's definition of `decorator_from_middleware()` was preventing
reversion integration tests from passing in projects that include
`RevisionMiddleware` in `MIDDLEWARE_CLASSES`.

To avoid this problem, this commit redefines `decorator_from_middleware()` to
return a decorator that does not reapply the middleware if it is in
`MIDDLEWARE_CLASSES`.  `@decorator_from_middleware(RevisionMiddleware)` is then
used to wrap almost all `RevisionMiddleware` test views.

Thanks to @pricem and @gkanwar for identifying this issue.
