### PR TITLE
Derive pk column name dynamically for Users.User table in initial migration

### DIFF
--- a/src/reversion/migrations/0001_initial.py
+++ b/src/reversion/migrations/0001_initial.py
@@ -65,7 +65,7 @@ class Migration(SchemaMigration):
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            User._meta.pk.column: ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),


### PR DESCRIPTION
Our **Users.User** class was an **AbstractUser** subclassing one of our own models, **Person**. In our database, the pk of the **users_user** table was **person_ptr_id**. Reversion's **0001_initial** migration was failing to make a foreign key because **users_user.id** did not exist. Changing **id** in the frozen ORM to **User._meta.pk.column** works for me.
