### PR TITLE
api.rst: note about duplicate add_meta calls

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -98,6 +98,7 @@ You can then attach this meta class to a revision using the following method::
 
     reversion.add_meta(VersionRating, rating=5)
 
+Be sure to only call ``add_meta`` once per meta class per revision context, otherwise you'll get a duplicate key error.
 
 Reverting to previous revisions
 -------------------------------


### PR DESCRIPTION
If you call add_meta twice with the same meta class you get
an IntegrityError:

```
IntegrityError: duplicate key value violates unique constraint "myapp_mymetaclass_revision_id_key"
DETAIL:  Key (revision_id)=(14203) already exists.
```

Make a note in the docs that you shouldn't call add_meta
twice during a revision context with the same meta class.
