### PR TITLE
Allow register to be used as a class decorator (#322)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,20 @@ If you're already using the :ref:`admin integration <admin>` for a model, then t
 
     reversion.register(YourModel)
 
+``reversion.register`` can also be used as a class decorator, with or without arguments.
+
+::
+
+    import reversion
+
+    @reversion.register
+    class YourModel(models.Model):
+        ...
+
+    @reversion.register(format='yaml')
+    class YourOtherModel(models.Model):
+        ...
+
 **Warning:** If you’re using django-reversion in an management command, and are using the automatic ``VersionAdmin`` registration method, then you’ll need to import the relevant ``admin.py`` file at the top of your management command file.
 
 **Warning:** When Django starts up, some python scripts get loaded twice, which can cause 'already registered' errors to be thrown. If you place your calls to ``reversion.register()`` in the ``models.py`` file, immediately after the model definition, this problem will go away.

--- a/src/reversion/tests.py
+++ b/src/reversion/tests.py
@@ -123,6 +123,20 @@ class RegistrationTest(TestCase):
         self.assertEqual(str(cm.exception),
                          "ReversionTestModel1Proxy is a proxy model, and cannot be used with django-reversion, register the parent class (ReversionTestModel1) instead.")  # noqa
 
+    def testDecorator(self):
+        # Test the use of register as a decorator
+        @reversion.register
+        class DecoratorModel(models.Model):
+            pass
+        self.assertTrue(reversion.is_registered(DecoratorModel))
+
+    def testDecoratorArgs(self):
+        # Test a decorator with arguments
+        @reversion.register(format='yaml')
+        class DecoratorArgsModel(models.Model):
+            pass
+        self.assertTrue(reversion.is_registered(DecoratorArgsModel))
+
 
 class ReversionTestBase(TestCase):
 


### PR DESCRIPTION
This patch allows `register` to be used as a class decorator, with or without extra arguments, following up on #322.  I've included tests and documentation.
