### PR TITLE
Added Django 1.7 RC2 to the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ env:
   - DJANGO=django==1.6.3
   - DJANGO=django==1.6.4
   - DJANGO=django==1.6.5
+  - DJANGO=https://www.djangoproject.com/download/1.7c2/tarball/
+matrix:
+  exclude:
+    - python: 2.6
+      env: DJANGO=https://www.djangoproject.com/download/1.7c2/tarball/
+  allow_failures:
+    - env: DJANGO=https://www.djangoproject.com/download/1.7c2/tarball/
 install:
   - pip install $DJANGO
   - python setup.py -q install


### PR DESCRIPTION
Note that Python 2.6 is no longer supported.
