### PR TITLE
fix for user lost when data been updated from outside the admin site

### DIFF
--- a/src/reversion/middleware.py
+++ b/src/reversion/middleware.py
@@ -25,7 +25,7 @@ class RevisionMiddleware(object):
         """Closes the revision."""
         if request.META.get(REVISION_MIDDLEWARE_FLAG, False):
             del request.META[REVISION_MIDDLEWARE_FLAG]
-            revision_context_manager.end()
+            revision_context_manager.end(request=request)
     
     def process_response(self, request, response):
         """Closes the revision."""

--- a/src/reversion/revisions.py
+++ b/src/reversion/revisions.py
@@ -159,7 +159,7 @@ class RevisionContextManager(local):
         """
         self._stack.append(manage_manually)
 
-    def end(self):
+    def end(self,request=None):
         """Ends a revision for this thread."""
         self._assert_active()
         self._stack.pop()
@@ -174,7 +174,7 @@ class RevisionContextManager(local):
                                 for obj, data
                                 in manager_context.items()
                             ),
-                            user = self._user,
+                            user = self._user or (hasattr(request, "user") and request.user),
                             comment = self._comment,
                             meta = self._meta,
                             ignore_duplicates = self._ignore_duplicates,


### PR DESCRIPTION
 the user/comment of the reversion log will get lost when data been updated from outside the admin site.
and my test code which shows the bug is available at https://github.com/TommyU/test_reversion/