### PR TITLE
Update django-versions.rst

### DIFF
--- a/docs/django-versions.rst
+++ b/docs/django-versions.rst
@@ -11,7 +11,7 @@ If you are using anything other than the latest release of Django, it is importa
 Django version  Reversion release
 ==============  =================
 1.7+            1.8.4
-1.6+            1.8.4
+1.6+            1.8.2
 1.5.1+          1.7.1
 1.5             1.7  
 1.4.4+          1.6.6


### PR DESCRIPTION
Looks like 1.8.3 was the first version that required django 1.7+