### PR TITLE
Make reverting a bit more fault tolerant by using the object's own save method as fallback

### DIFF
--- a/src/reversion/models.py
+++ b/src/reversion/models.py
@@ -195,6 +195,7 @@ class Version(models.Model):
                 object_version.save()
         except IntegrityError:
             object_version.object.save()
+            object_version.save()
 
     def __str__(self):
         """Returns a unicode representation."""


### PR DESCRIPTION
The usecase for this is an undelete action that failed on me because I had added a "modified_at" field with auto_now=True.

The way I circumvented this is by falling back to object_version.object.save(). This requires the previous attempt to be rolled back however, so I had to apply transaction.atomic in a few places.

This passes all the unit tests and works on my local testcase with the auto_now=True field, but I'm not sure if this might cause problems in some edge case. Input is very welcome.