### PR TITLE
Support for MySQL utf8mb4

### DIFF
--- a/src/reversion/migrations/0002_auto_20141216_1509.py
+++ b/src/reversion/migrations/0002_auto_20141216_1509.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('reversion', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='revision',
+            name='manager_slug',
+            field=models.CharField(default='default', max_length=191, db_index=True),
+        ),
+    ]

--- a/src/reversion/models.py
+++ b/src/reversion/models.py
@@ -46,7 +46,7 @@ class Revision(models.Model):
     """A group of related object versions."""
 
     manager_slug = models.CharField(
-        max_length = 200,
+        max_length = 191,
         db_index = True,
         default = "default",
     )


### PR DESCRIPTION
As outlined in http://dev.mysql.com/doc/refman/5.5/en/charset-unicode-upgrading.html

> InnoDB has a maximum index length of 767 bytes, so for utf8 or utf8mb4 columns, you can index a maximum of 255 or 191 characters, respectively. If you currently have utf8 columns with indexes longer than 191 characters, you will need to index a smaller number of characters. In an InnoDB table, these column and index definitions are legal:

This change ensures those using the InnoDB storage engine in MySQL with utf8mb4_* collations can use reversion.
