### PR TITLE
Fix Django 1.8+ warnings by importing from django.contrib.admin.utils (plural)

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -9,7 +9,10 @@ from django.db import models, transaction, connection
 from django.conf.urls import patterns, url
 from django.contrib import admin
 from django.contrib.admin import helpers, options
-from django.contrib.admin.utils import unquote, quote
+try:
+    from django.contrib.admin.utils import unquote, quote
+except ImportError:  # Django < 1.7
+    from django.contrib.admin.util import unquote, quote
 from django.contrib.contenttypes.generic import GenericInlineModelAdmin, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse

--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -9,7 +9,7 @@ from django.db import models, transaction, connection
 from django.conf.urls import patterns, url
 from django.contrib import admin
 from django.contrib.admin import helpers, options
-from django.contrib.admin.util import unquote, quote
+from django.contrib.admin.utils import unquote, quote
 from django.contrib.contenttypes.generic import GenericInlineModelAdmin, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
Closes #384.