### PR TITLE
Properly handles a scenario when an instance's PK is None

### DIFF
--- a/src/reversion/revisions.py
+++ b/src/reversion/revisions.py
@@ -174,6 +174,7 @@ class RevisionContextManager(local):
                                 (obj, callable(data) and data() or data)
                                 for obj, data
                                 in manager_context.items()
+                                if obj.pk
                             ),
                             user = self._user,
                             comment = self._comment,

--- a/src/reversion/revisions.py
+++ b/src/reversion/revisions.py
@@ -174,7 +174,7 @@ class RevisionContextManager(local):
                                 (obj, callable(data) and data() or data)
                                 for obj, data
                                 in manager_context.items()
-                                if obj.pk
+                                if obj.pk is not None
                             ),
                             user = self._user,
                             comment = self._comment,


### PR DESCRIPTION
When copying instances in Django, the standard way of doing it is setting an object's PK as None. As of some versions of Django, when a related field is assigned, a save event is triggered and if that assignment was done on the object that was being copied and had a PK of None it created a conflict with django-reversion.

When reversion tried to save changes done to the object, it could not locate the PK of the object, raising an Exception since the int() conversion of None returns a ValueError.

This PR fixes it by checking that the object that will be saved in the revision has a PK that is not None and thus skips it.