### PR TITLE
Test that creating and deleting instance does not create version

### DIFF
--- a/src/tests/test_reversion/tests.py
+++ b/src/tests/test_reversion/tests.py
@@ -250,6 +250,14 @@ class InternalsTest(RevisionTestBase):
         self.assertEqual(Revision.objects.count(), 2)
         self.assertEqual(Version.objects.count(), 5)
 
+    def testNoVersionForObjectCreatedAndDeleted(self):
+        with reversion.create_revision():
+            new_object = ReversionTestModel1.objects.create()
+            new_object.delete()
+        # No Revision and no Version should have been created.
+        self.assertEqual(Revision.objects.count(), 1)
+        self.assertEqual(Version.objects.count(), 4)
+
 
 class ApiTest(RevisionTestBase):
 


### PR DESCRIPTION
This verifies that #391 has indeed been fixed.

Adds a test that verifies that creating and deleting a model instance
within a reversion does not create a new version.