### PR TITLE
Fix deleterevisions' user choice prompt to work with Python 2

### DIFF
--- a/src/reversion/management/commands/deleterevisions.py
+++ b/src/reversion/management/commands/deleterevisions.py
@@ -1,12 +1,13 @@
 from __future__ import unicode_literals
 
-import datetime, operator, sys
+import datetime, operator
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 from django.db.models import Q, Count
 from django.contrib.contenttypes.models import ContentType
+from django.utils.six.moves import input
 
 from reversion.models import Revision, Version
 from django.db.utils import DatabaseError
@@ -195,17 +196,7 @@ Examples:
 
         # Ask confirmation
         if confirmation:
-            prompt = "Are you sure you want to delete theses revisions? [y|N] "
-            try:
-                # Use `raw_input` function in Python 2
-                choice = raw_input(prompt)
-            except NameError:
-                # If `raw_input` function is not available we are probably in
-                # Python 3, in which the function was renamed `input`:
-                # https://www.python.org/dev/peps/pep-3111/
-                # NOTE: We really don't want to end up here in Python 2, as
-                # input() would then eval the user input as Python code.
-                choice = input(prompt)
+            choice = input("Are you sure you want to delete theses revisions? [y|N] ")
             if choice.lower() != "y":
                 print("Aborting revision deletion.")
                 return

--- a/src/reversion/management/commands/deleterevisions.py
+++ b/src/reversion/management/commands/deleterevisions.py
@@ -195,11 +195,17 @@ Examples:
 
         # Ask confirmation
         if confirmation:
+            prompt = "Are you sure you want to delete theses revisions? [y|N] "
             try:
-                raw_input = raw_input
+                # Use `raw_input` function in Python 2
+                choice = raw_input(prompt)
             except NameError:
-                raw_input = input
-            choice = raw_input("Are you sure you want to delete theses revisions? [y|N] ")
+                # If `raw_input` function is not available we are probably in
+                # Python 3, in which the function was renamed `input`:
+                # https://www.python.org/dev/peps/pep-3111/
+                # NOTE: We really don't want to end up here in Python 2, as
+                # input() would then eval the user input as Python code.
+                choice = input(prompt)
             if choice.lower() != "y":
                 print("Aborting revision deletion.")
                 return


### PR DESCRIPTION
When prompting the user for a y/n choice, the deleterevisions command
was failing for me in Python 2.7.9 because it was falling back to use
input() instead of raw_input().

This fallback is appropriate for Python 3 in which raw_input() was
replaced by input(), but should never be done in Python 2 because there
the input() function evaluates the user input as code.

I am not really sure why the attempted Python 2/3 recognition technique
of assigning the raw_input function to itself fails to work correctly
for me, but this restructured version should accomplish the same thing
with less chance of incorrectly assuming it is in Python 3.