### PR TITLE
Add revision manager that auto-registers models in follow relationships

### DIFF
--- a/src/reversion/revisions.py
+++ b/src/reversion/revisions.py
@@ -331,7 +331,8 @@ class RevisionManager(object):
             return cls._created_managers[manager_slug]
         raise RegistrationError("No revision manager exists with the slug %r" % manager_slug)
 
-    def __init__(self, manager_slug, revision_context_manager=revision_context_manager):
+    def __init__(self, manager_slug, adapter_cls=VersionAdapter,
+                 revision_context_manager=revision_context_manager):
         """Initializes the revision manager."""
         # Check the slug is unique for this revision manager.
         if manager_slug in RevisionManager._created_managers:
@@ -341,6 +342,7 @@ class RevisionManager(object):
         # Store config params.
         self._manager_slug = manager_slug
         self._registered_models = {}
+        self._adapter_cls = adapter_cls
         self._revision_context_manager = revision_context_manager
         self._eager_signals = {}
         self._signals = {}
@@ -371,8 +373,11 @@ class RevisionManager(object):
             in self._registered_models.keys()
         ]
 
-    def register(self, model=None, adapter_cls=VersionAdapter, signals=None, eager_signals=None, **field_overrides):
+    def register(self, model=None, adapter_cls=None, signals=None, eager_signals=None, **field_overrides):
         """Registers a model with this revision manager."""
+        # Use default adapter class unless overridden in this method call
+        if adapter_cls is None:
+            adapter_cls = self._adapter_cls
         # Default to post_save if no signals are given
         if signals is None and eager_signals is None:
             signals = [post_save]

--- a/src/tests/test_reversion/models.py
+++ b/src/tests/test_reversion/models.py
@@ -57,6 +57,22 @@ class TestFollowModel(ReversionTestModelBase):
     )
 
 
+class TestAutoRegisterChild(ReversionTestModelBase):
+    pass
+
+
+class TestAutoRegisterParent(ReversionTestModelBase):
+
+    child = models.ForeignKey(
+        TestAutoRegisterChild,
+        null=True,
+    )
+
+    children = models.ManyToManyField(
+        TestAutoRegisterChild,
+    )
+
+
 class ReversionTestModel1Proxy(ReversionTestModel1):
 
     class Meta:

--- a/src/tests/test_reversion/tests.py
+++ b/src/tests/test_reversion/tests.py
@@ -117,6 +117,35 @@ class RegistrationTest(TestCase):
         self.assertFalse(ReversionTestModel3 in reversion.default_revision_manager._signals)
         self.assertFalse(ReversionTestModel3 in reversion.default_revision_manager._eager_signals)
 
+    def testRevisionManagerDefaultAdapter(self):
+        # Default adapter is used unless overridden
+        class TestModel1(models.Model):
+            pass
+        reversion.register(TestModel1)
+        self.assertTrue(reversion.is_registered(TestModel1))
+        self.assertEqual(reversion.VersionAdapter,
+                         reversion.get_adapter(TestModel1).__class__)
+        # Can specify default adapter for a revision manager class
+        class CustomVersionAdapter1(reversion.VersionAdapter):
+            pass
+        class TestModel2(models.Model):
+            pass
+        rev_manager = RevisionManager("test-manager-1",
+                                      adapter_cls=CustomVersionAdapter1)
+        rev_manager.register(TestModel2)
+        self.assertTrue(rev_manager.is_registered(TestModel2))
+        self.assertEqual(CustomVersionAdapter1,
+                         rev_manager.get_adapter(TestModel2).__class__)
+        # Can override revision manager's default adapter on `register` call
+        class CustomVersionAdapter2(reversion.VersionAdapter):
+            pass
+        class TestModel3(models.Model):
+            pass
+        rev_manager.register(TestModel3, adapter_cls=CustomVersionAdapter2)
+        self.assertTrue(rev_manager.is_registered(TestModel3))
+        self.assertEqual(CustomVersionAdapter2,
+                         rev_manager.get_adapter(TestModel3).__class__)
+
 
 class ReversionTestBase(TestCase):
 


### PR DESCRIPTION
Add a new `AutoRegisterRevisionManager` implementation of `RevisionManager` that will automatically register unregistered model classes encountered via `follow` relationships when saving a new revision.

The auto-registration feature is intended to help add versioning support to a CMS where there can be a complex object relationship model and a set of content types models that grows over time, where manually adding explicit `register` calls for every model is repetitive and easy to forget.

PR also includes a `RevisionManager` change so on init you can set a default adapter class to use when registering models, making it easier to use a custom adapter for all model registrations without needing to provide the adapter as an argument with every `register` call.

For context, this work is being used as part of an effort to add reversion support to django-fluent-pages, see use of `AutoRegisterRevisionManager` at bottom: https://github.com/ixc/django-fluent-pages/blob/reversion_support/fluent_pages/integration/django_reversion/utils.py
