### PR TITLE
Add support for "strict" revert to Django admin integration

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -279,12 +279,13 @@ class VersionAdmin(admin.ModelAdmin):
         # Generate the model form.
         ModelForm = self.get_form(request, obj)
         formsets = []
+        is_strict_revert = getattr(settings, 'REVERSION_ADMIN_STRICT_REVERT', False)
         if request.method == "POST":
             was_reverted = False
 
             # If configured to restore exact version data, do so without
             # processing any submitted form data which may have been altered...
-            if getattr(settings, 'REVERSION_ADMIN_STRICT_REVERT', False):
+            if is_strict_revert:
                 self._perform_strict_revert(request, obj, version, context,
                                             revert=revert, recover=recover)
                 new_object = model.objects.get(pk=object_id)
@@ -390,6 +391,7 @@ class VersionAdmin(admin.ModelAdmin):
                         "change": True,
                         "revert": revert,
                         "recover": recover,
+                        "is_strict_revert": is_strict_revert,
                         "has_add_permission": self.has_add_permission(request),
                         "has_change_permission": self.has_change_permission(request, obj),
                         "has_delete_permission": self.has_delete_permission(request, obj),

--- a/src/tests/test_reversion/admin.py
+++ b/src/tests/test_reversion/admin.py
@@ -4,6 +4,7 @@ import reversion
 
 from test_reversion.models import (
     ChildTestAdminModel,
+    StrictChildTestAdminModel,
     InlineTestChildModel,
     InlineTestParentModel,
     InlineTestUnrelatedChildModel,
@@ -20,6 +21,14 @@ class ChildTestAdminModelAdmin(reversion.VersionAdmin):
 
 
 site.register(ChildTestAdminModel, ChildTestAdminModelAdmin)
+
+
+class StrictChildTestAdminModelAdmin(reversion.VersionAdmin):
+
+    strict_revert = True  # Enable strict admin revert/restore
+
+
+site.register(StrictChildTestAdminModel, StrictChildTestAdminModelAdmin)
 
 
 class InlineTestChildModelInline(admin.TabularInline):

--- a/src/tests/test_reversion/models.py
+++ b/src/tests/test_reversion/models.py
@@ -90,6 +90,10 @@ class ChildTestAdminModel(ParentTestAdminModel):
         return self.child_name
 
 
+class StrictChildTestAdminModel(ChildTestAdminModel):
+    pass
+
+
 class InlineTestParentModel(models.Model):
 
     name = models.CharField(


### PR DESCRIPTION
Add support for "strict" revert/restore in Django admin integration if the new `VersionAdmin.strict_revert` class attribute is True (defaults to False)

When strict revert is enabled and you revert/restore version data via the built-in Django admin integration, the *exact* prior version will be restored and any modifications made in the submitted admin form data will be ignored.

This change makes it possible to safely revert complex object graphs without needing to guarantee that *every* piece of data in the prior version is also properly represented in a single admin form, which isn't always possible for situations like a CMS where one object may have multiple translatable fields that are managed by loading different translations into a single base admin form depending on the current language of interest.

For context, this work is being used as part of an effort to add reversion support to django-fluent-pages: https://github.com/ixc/django-fluent-pages/tree/reversion_support