### PR TITLE
Improve support for versioning polymorphic models in Django admin integration

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -370,7 +370,7 @@ class VersionAdmin(admin.ModelAdmin):
                         "has_delete_permission": self.has_delete_permission(request, obj),
                         "has_file_field": True,
                         "has_absolute_url": False,
-                        "form_url": mark_safe(request.path),
+                        "form_url": mark_safe(request.get_full_path()),
                         "opts": opts,
                         "content_type_id": ContentType.objects.get_for_model(self.model).id,
                         "save_as": False,

--- a/src/reversion/templates/reversion/recover_list.html
+++ b/src/reversion/templates/reversion/recover_list.html
@@ -26,10 +26,12 @@
                     </thead>
                     <tbody>
                         {% for deletion in deleted %}
+                            {% with ct_id=deletion.field_dict.polymorphic_ctype %}
                             <tr>
-                                <th scope="row"><a href="{{deletion.pk|unlocalize}}/">{{deletion.revision.date_created}}</a></th>
+                                <th scope="row"><a href="{{deletion.pk|unlocalize}}/{% if ct_id %}?ct_id={{ct_id}}{% endif %}">{{deletion.revision.date_created}}</a></th>
                                 <td>{{deletion.object_repr}}</td>
                             </tr>
+                            {% endwith %}
                         {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
Improved handling of polymorphic models in Django admin:

* include `ct_id` context type URL parameter in recover listing and detail form when appropriate
* recognise related version data relevant to inline forms in edge-case situations where the version's apparent content type does not match the actual class that was versioned.

For context, this work is being used as part of an effort to add reversion support to django-fluent-pages: https://github.com/ixc/django-fluent-pages/tree/reversion_support