### PR TITLE
Add content type ID to links on recover list page for polymorphic items

### DIFF
--- a/src/reversion/templates/reversion/recover_list.html
+++ b/src/reversion/templates/reversion/recover_list.html
@@ -26,10 +26,12 @@
                     </thead>
                     <tbody>
                         {% for deletion in deleted %}
+                            {% with ct_id=deletion.field_dict.polymorphic_ctype %}
                             <tr>
-                                <th scope="row"><a href="{% url opts|admin_urlname:'recover' deletion.pk %}">{{deletion.revision.date_created}}</a></th>
+                                <th scope="row"><a href="{% url opts|admin_urlname:'recover' deletion.pk %}{% if ct_id %}?ct_id={{ct_id}}{% endif %}">{{deletion.revision.date_created}}</a></th>
                                 <td>{{deletion.object_repr}}</td>
                             </tr>
+                            {% endwith %}
                         {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
If a deleted item listed on the recover list page is a polymorphic
type -- as identified with a 'polymorphic_ctype' value in the version
data dict -- add the value as a '?ct_id' parameter on the item's link
to inform the recover page detail view of the item's polymorphic type.