### PR TITLE
Support pre_delete signal in admin

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -174,6 +174,10 @@ class VersionAdmin(admin.ModelAdmin):
         with self._create_revision(request):
             return super(VersionAdmin, self).change_view(request, object_id, form_url, extra_context)
 
+    def delete_view(self, request, *args, **kwargs):
+        with self._create_revision(request):
+            return super(VersionAdmin, self).delete_view(request, *args, **kwargs)
+
     def revisionform_view(self, request, version, template_name, extra_context=None):
         try:
             with transaction.atomic():


### PR DESCRIPTION
Without this change 'pre_delete' eager signal is not creating any revision.
I'm not using version middleware to track only admin changes. With this change and eager_signal=[pre_delete] is delete/undelete of model without initial version working.