### PR TITLE
Change order of `available_versions` in example

### DIFF
--- a/docs/diffs.rst
+++ b/docs/diffs.rst
@@ -24,8 +24,8 @@ First of all, you need to use the :ref:`low level API <api>` to retrieve the ver
     # Get the two versions to compare.
     available_versions = reversion.get_for_object(page)
 
-    old_version = available_versions[0]
-    new_version = available_versions[1]
+    new_version = available_versions[0]
+    old_version = available_versions[1]
 
 Now, in order to generate a text patch::
 


### PR DESCRIPTION
`reversion.get_for_object()` should return versions in a reversed-chronological order. So, `available_versions[0]` would reflect the latest change.