### PR TITLE
Fixed Issue 465: Proxy registration option should be independent from their concrete models

### DIFF
--- a/src/tests/test_reversion/admin.py
+++ b/src/tests/test_reversion/admin.py
@@ -15,6 +15,9 @@ from test_reversion.models import (
     InlineTestUnrelatedChildModel,
     InlineTestUnrelatedParentModel,
     InlineTestChildGenericModel,
+    ReversionTestModel1Proxy,
+    TestFollowModel,
+    TestFollowModelProxy
 )
 
 
@@ -86,3 +89,19 @@ class InlineTestUnrelatedParentModelAdmin(VersionAdmin):
 
 
 admin.site.register(InlineTestUnrelatedParentModel, InlineTestUnrelatedParentModelAdmin)
+
+
+# Issue 465
+from reversion import revisions
+revisions.register(TestFollowModel)
+
+
+class TestFollowModelProxyAdmin(admin.TabularInline):
+    model = TestFollowModelProxy
+    fields = ('name',)
+
+
+class ReversionTestModel1ProxyAdmin(VersionAdmin):
+    inlines = [TestFollowModelProxyAdmin]
+
+admin.site.register(ReversionTestModel1Proxy, ReversionTestModel1ProxyAdmin)

--- a/src/tests/test_reversion/models.py
+++ b/src/tests/test_reversion/models.py
@@ -176,3 +176,8 @@ class InlineTestUnrelatedParentModel(models.Model):
 class InlineTestUnrelatedChildModel(models.Model):
 
     parent = models.ForeignKey(InlineTestUnrelatedParentModel)
+
+# Issue #465
+class TestFollowModelProxy(TestFollowModel):
+    class Meta:
+        proxy = True


### PR DESCRIPTION
A concept proof, 
Edited 2 tests which assumes proxy models == concrete models.
No regression tests yet,Testing might get more aggressive especially ensuring that proxies are totally independent.


