### PR TITLE
Return 404 rather then 500 due to ValueError in reversion view methods.

### DIFF
--- a/src/reversion/admin.py
+++ b/src/reversion/admin.py
@@ -166,8 +166,8 @@ class VersionAdmin(admin.ModelAdmin):
         info = opts.app_label, opts.model_name,
         reversion_urls = [
                                   url("^recover/$", admin_site.admin_view(self.recoverlist_view), name='%s_%s_recoverlist' % info),
-                                  url("^recover/([^/]+)/$", admin_site.admin_view(self.recover_view), name='%s_%s_recover' % info),
-                                  url("^([^/]+)/history/([^/]+)/$", admin_site.admin_view(self.revision_view), name='%s_%s_revision' % info),]
+                                  url("^recover/(\d+)/$", admin_site.admin_view(self.recover_view), name='%s_%s_recover' % info),
+                                  url("^([^/]+)/history/(\d+)/$", admin_site.admin_view(self.revision_view), name='%s_%s_revision' % info),]
         return reversion_urls + urls
 
     # Views.


### PR DESCRIPTION
Both `recover_view` (at https://github.com/etianen/django-reversion/blob/master/src/reversion/admin.py#L209) and `revision_view` (at https://github.com/etianen/django-reversion/blob/master/src/reversion/admin.py#L219) call `get_object_or_404` which will raise a ValueError if a non-integer is passed to the version_id parameter. 