### PR TITLE
do not do heavy queries if no objects would be deleted anyway

### DIFF
--- a/reversion/migrations/0003_auto_20160601_1600.py
+++ b/reversion/migrations/0003_auto_20160601_1600.py
@@ -21,11 +21,9 @@ def de_dupe_version_table(apps, schema_editor):
         # Add in the most recent id for each duplicate row.
         max_pk=models.Max("pk"),
     ).values_list("max_pk", flat=True)
-
     # Do not do anything if we're keeping all ids anyway.
     if keep_version_ids.count() == Version.objects.all().count():
         return
-
     # Delete all duplicate versions. Can't do this as a delete with subquery because MySQL doesn't like running a
     # subquery on the table being updated/deleted.
     delete_version_ids = list(Version.objects.exclude(

--- a/reversion/migrations/0003_auto_20160601_1600.py
+++ b/reversion/migrations/0003_auto_20160601_1600.py
@@ -21,6 +21,11 @@ def de_dupe_version_table(apps, schema_editor):
         # Add in the most recent id for each duplicate row.
         max_pk=models.Max("pk"),
     ).values_list("max_pk", flat=True)
+
+    # Do not do anything if we're keeping all ids anyway.
+    if keep_version_ids.count() == Version.objects.all().count():
+        return
+
     # Delete all duplicate versions. Can't do this as a delete with subquery because MySQL doesn't like running a
     # subquery on the table being updated/deleted.
     delete_version_ids = list(Version.objects.exclude(


### PR DESCRIPTION
As mentioned in #541, de_dupe_version_table in migration 0003 is very heavy. At least in my case, it turned out that the query wasn't necessary at all:

```
>>> from reversion.models import Version
>>> from django.db import models
>>> keep_version_ids = Version.objects.order_by().values_list(
        # Group by the unique constraint we intend to enforce.
        "revision_id",
        "content_type_id",
        "object_id",
    ).annotate(
        # Add in the most recent id for each duplicate row.
        max_pk=models.Max("pk"),
    ).values_list("max_pk", flat=True)
>>> keep_version_ids.count()
806866
>>> Version.objects.all().count()
806866
```

The subsequent statement is what takes so incredibly long, so this pull request would be a significant speedup in this case (I don't know how likely this is, but at least it was true for me)
