### PR TITLE
Missing database index on object_id!

### DIFF
--- a/reversion/models.py
+++ b/reversion/models.py
@@ -155,6 +155,7 @@ class Version(models.Model):
     object_id = models.CharField(
         max_length=191,
         help_text="Primary key of the model under version control.",
+        db_index=True,
     )
 
     content_type = models.ForeignKey(


### PR DESCRIPTION
There's a missing index on object_id, this is creating a sequential scan instead of an index lookup when grabbing all reversions for an object: http://share.aidanlister.com/gmPY