### PR TITLE
added `revert` and `recover` context variables to mirror Django's

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -200,6 +200,7 @@ class VersionAdmin(admin.ModelAdmin):
         version = get_object_or_404(Version, pk=version_id)
         context = {
             "title": _("Recover %(name)s") % {"name": version.object_repr},
+            "recover": True,
         }
         context.update(extra_context or {})
         return self._reversion_revisionform_view(
@@ -215,6 +216,7 @@ class VersionAdmin(admin.ModelAdmin):
         version = get_object_or_404(Version, pk=version_id, object_id=object_id)
         context = {
             "title": _("Revert %(name)s") % {"name": version.object_repr},
+            "revert": True,
         }
         context.update(extra_context or {})
         return self._reversion_revisionform_view(

--- a/tests/test_app/tests/test_admin.py
+++ b/tests/test_app/tests/test_admin.py
@@ -84,6 +84,8 @@ class AdminRevisionViewTest(LoginMixin, AdminMixin, TestBase):
         self.obj.refresh_from_db()
         self.assertEqual(self.obj.name, "v2")
         self.assertEqual(self.obj.parent_name, "parent v2")
+        self.assertIn("revert", response.context)
+        self.assertTrue(response.context["revert"])
 
     def testRevisionViewOldRevision(self):
         response = self.client.get(resolve_url(
@@ -135,6 +137,8 @@ class AdminRecoverViewTest(LoginMixin, AdminMixin, TestBase):
         ))
         self.assertContains(response, 'value="v1"')
         self.assertContains(response, 'value="parent v1"')
+        self.assertIn("recover", response.context)
+        self.assertTrue(response.context["recover"])
 
     def testRecoverViewRecover(self):
         self.client.post(resolve_url(


### PR DESCRIPTION
As per conversation in #564 (where I misnamed the potential variables, but we ultimately settled on a pair), this adds new context variables to a VersionAdmin when rendering the changeform view, which allow the template or middleware to establish which view is being rendered. Their absence indicates it was not the view in question.