### PR TITLE
Reintroduce pre_revision_commit and post_revision_commit signals

### DIFF
--- a/docs/_include/signal-args.rst
+++ b/docs/_include/signal-args.rst
@@ -1,0 +1,8 @@
+``sender``
+    The ``reversion.create_revision`` object.
+
+``revision``
+    The :ref:`Revision` model.
+
+``versions``
+    The :ref:`Version` models in the revision.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,3 +70,4 @@ Usage
    views
    middleware
    errors
+   signals

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -1,0 +1,22 @@
+.. _signals:
+
+Signals
+=======
+
+django-reversion provides two custom signals.
+
+
+reversion.signals.pre_revision_commit
+-------------------------------------
+
+Sent just before a revision is saved to the database.
+
+.. include:: /_include/signal-args.rst
+
+
+reversion.signals.post_revision_commit
+--------------------------------------
+
+Sent just after a revision and its related versions are saved to the database.
+
+.. include:: /_include/signal-args.rst

--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -13,6 +13,7 @@ from django.utils.encoding import force_text
 from django.utils import timezone, six
 from reversion.compat import remote_field
 from reversion.errors import RevisionManagementError, RegistrationError
+from reversion.signals import pre_revision_commit, post_revision_commit
 
 
 _VersionOptions = namedtuple("VersionOptions", (
@@ -222,6 +223,12 @@ def _save_revision(versions, user=None, comment="", meta=(), date_created=None, 
         user=user,
         comment=comment,
     )
+    # Send the pre_revision_commit signal.
+    pre_revision_commit.send(
+        sender=create_revision,
+        revision=revision,
+        versions=versions,
+    )
     # Save the revision.
     revision.save(using=using)
     # Save version models.
@@ -234,6 +241,12 @@ def _save_revision(versions, user=None, comment="", meta=(), date_created=None, 
             revision=revision,
             **meta_fields
         )
+    # Send the post_revision_commit signal.
+    post_revision_commit.send(
+        sender=create_revision,
+        revision=revision,
+        versions=versions,
+    )
 
 
 @contextmanager

--- a/reversion/signals.py
+++ b/reversion/signals.py
@@ -1,0 +1,10 @@
+from django.dispatch.dispatcher import Signal
+
+
+_signal_args = [
+    "revision",
+    "versions",
+]
+
+pre_revision_commit = Signal(providing_args=_signal_args)
+post_revision_commit = Signal(providing_args=_signal_args)

--- a/tests/test_app/tests/test_api.py
+++ b/tests/test_app/tests/test_api.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     from mock import MagicMock
 
+
 class SaveTest(TestModelMixin, TestBase):
 
     def testModelSave(self):

--- a/tests/test_app/tests/test_api.py
+++ b/tests/test_app/tests/test_api.py
@@ -6,6 +6,10 @@ import reversion
 from test_app.models import TestModel, TestModelRelated, TestModelThrough, TestModelParent, TestMeta
 from test_app.tests.base import TestBase, TestModelMixin, UserMixin
 
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 class SaveTest(TestModelMixin, TestBase):
 
@@ -107,6 +111,22 @@ class CreateRevisionTest(TestModelMixin, TestBase):
     def testCreateRevisionDecorator(self):
         obj = reversion.create_revision()(TestModel.objects.create)()
         self.assertSingleRevision((obj,))
+
+    def testPreRevisionCommitSignal(self):
+        _callback = MagicMock()
+        reversion.signals.pre_revision_commit.connect(_callback)
+
+        with reversion.create_revision():
+            TestModel.objects.create()
+        self.assertEqual(_callback.call_count, 1)
+
+    def testPostRevisionCommitSignal(self):
+        _callback = MagicMock()
+        reversion.signals.post_revision_commit.connect(_callback)
+
+        with reversion.create_revision():
+            TestModel.objects.create()
+        self.assertEqual(_callback.call_count, 1)
 
 
 class CreateRevisionManageManuallyTest(TestModelMixin, TestBase):

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 [testenv]
 usedevelop = True
 deps =
+    py27: mock
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django==1.10a1


### PR DESCRIPTION
Rationale: https://github.com/etianen/django-reversion/issues/571
Related commit: 09ce3764c1404747ebb90379cd79e193f3f58164