### PR TITLE
Fix postgresql vendor name

### DIFF
--- a/reversion/models.py
+++ b/reversion/models.py
@@ -294,7 +294,7 @@ def _safe_subquery(method, left_query, left_field_name, right_subquery, right_fi
         left_query.db != right_subquery.db or not
         (
             left_field.get_internal_type() != right_field.get_internal_type() and
-            connections[left_query.db].vendor in ("sqlite", "postgres")
+            connections[left_query.db].vendor in ("sqlite", "postgresql")
         )
     ):
         right_subquery = list(right_subquery.iterator())


### PR DESCRIPTION
All supported django versions have `'postgresql'`, not `'postgres'` vendor name for PostgreSQL database:
- [django 1.8](https://github.com/django/django/blob/stable/1.8.x/django/db/backends/postgresql_psycopg2/base.py#L68)
- [django 1.9](https://github.com/django/django/blob/stable/1.9.x/django/db/backends/postgresql/base.py#L68)
- [django 1.10](https://github.com/django/django/blob/stable/1.10.x/django/db/backends/postgresql/base.py#L68)

But in django_reversion [_safe_subquery](https://github.com/etianen/django-reversion/blob/master/reversion/models.py#L297) function `'postgres'` is used in comparison. As a result, code like

    Version.objects.get_deleted(MyModel)

will do some in-memory stuff, which results in significantly lower performance.