### PR TITLE
Add changelog note on models ordering change done in 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -248,6 +248,10 @@ Helpers
 
     The old implementation is available for reference from the `previous release <https://github.com/etianen/django-reversion/blob/release-1.10.2/src/reversion/helpers.py>`_.
 
+Models
+^^^^^^
+
+* **Breaking:** Ordering of ``-pk`` added to models ``Revision`` and ``Version``. Previous was the default ``pk``.
 
 1.10.2 - 18/04/2016
 -------------------


### PR DESCRIPTION
Noticed the ordering of the `Revision` and `Version` models was reversed in 2.0, [in this commit](https://github.com/etianen/django-reversion/commit/8a3a6c369fd4d16253884dd31c98969065d1e26e#diff-848d9ceb3ff77cf47a950aa6c22852daR99). This caused a little confusion when updating, since `.last()` was now `.first()`.

A changelog entry on this might help future upgraders to check their code.

Thanks for your work on the library.