### PR TITLE
Update recover_list.html

### DIFF
--- a/reversion/templates/reversion/recover_list.html
+++ b/reversion/templates/reversion/recover_list.html
@@ -27,7 +27,7 @@
                     <tbody>
                         {% for deletion in deleted %}
                             <tr>
-                                <th scope="row"><a href="{% url opts|admin_urlname:'recover' deletion.pk %}">{{deletion.revision.date_created}}</a></th>
+                                <th scope="row"><a href="{% url opts|admin_urlname:'recover' deletion.pk|unlocalize %}">{{deletion.revision.date_created}}</a></th>
                                 <td>{{deletion.object_repr}}</td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
When deletion.pk is larger than 1k  in some localizations settings Django adds space between thousnads (for example: "1 000") and cause bug in url (creates inaccesible url)