### PR TITLE
Update changelog with additional breaking change in API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -169,6 +169,8 @@ Low-level API
 
 * **Breaking:** ``reversion.get_deleted()`` has been moved to ``Version.objects.get_deleted()`` (@etianen).
 
+* **Breaking:** ``Version.object_version`` has been renamed to ``Version._object_version`` (@etianen).
+
 * **Breaking:** Refactored multi-db support (@etianen).
 
     django-reversion now supports restoring model instances to their original database automatically. Several parameter names have also be updated to match Django coding conventions.


### PR DESCRIPTION
Was updating from 1.10.1 to 2.0.8 and found this additional breaking change. 

Here's when it was changed: https://github.com/etianen/django-reversion/commit/85ae48c3266d726e38d45778dca6be26f0465647#diff-848d9ceb3ff77cf47a950aa6c22852daL190
