### PR TITLE
Updated '_set_user_from_request' to make sure that request user is not empty

### DIFF
--- a/reversion/views.py
+++ b/reversion/views.py
@@ -15,7 +15,7 @@ def _request_creates_revision(request):
 
 
 def _set_user_from_request(request):
-    if hasattr(request, "user") and is_authenticated(request.user) and get_user() is None:
+    if getattr(request, "user", None) and is_authenticated(request.user) and get_user() is None:
         set_user(request.user)
 
 


### PR DESCRIPTION
Currently this code fails if `request.user == None` with `AttributeError: 'NoneType' object has no attribute 'is_authenticated'`.

It could be worth adding a test which I can do in the evening.

Fixes #648