### PR TITLE
Fix issue with admin and special characters in primary keys

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -184,7 +184,7 @@ class VersionAdmin(admin.ModelAdmin):
                 version.revision.revert(delete=True)
                 # Run the normal changeform view.
                 with self.create_revision(request):
-                    response = self.changeform_view(request, version.object_id, request.path, extra_context)
+                    response = self.changeform_view(request, quote(version.object_id), request.path, extra_context)
                     # Decide on whether the keep the changes.
                     if request.method == "POST" and response.status_code == 302:
                         set_comment(_("Reverted to previous version, saved on %(datetime)s") % {
@@ -277,7 +277,6 @@ class VersionAdmin(admin.ModelAdmin):
         # Check if user has change permissions for model
         if not self.has_change_permission(request):
             raise PermissionDenied
-        object_id = unquote(object_id)  # Underscores in primary key get quoted to "_5F"
         opts = self.model._meta
         action_list = [
             {
@@ -290,7 +289,7 @@ class VersionAdmin(admin.ModelAdmin):
             for version
             in self._reversion_order_version_queryset(Version.objects.get_for_object_reference(
                 self.model,
-                object_id,
+                unquote(object_id),  # Underscores in primary key get quoted to "_5F"
             ).select_related("revision__user"))
         ]
         # Compile the context.

--- a/tests/test_app/migrations/0001_initial.py
+++ b/tests/test_app/migrations/0001_initial.py
@@ -69,6 +69,12 @@ class Migration(migrations.Migration):
             ],
             bases=('test_app.testmodel',),
         ),
+        migrations.CreateModel(
+            name='TestModelEscapePK',
+            fields=[
+                ('name', models.CharField(max_length=191, primary_key=True, serialize=False)),
+            ],
+        ),
         migrations.AddField(
             model_name='testmodelthrough',
             name='test_model',

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -45,6 +45,11 @@ class TestModel(models.Model):
     generic_inlines = GenericRelation(TestModelGenericInline)
 
 
+class TestModelEscapePK(models.Model):
+
+    name = models.CharField(max_length=191, primary_key=True)
+
+
 class TestModelThrough(models.Model):
 
     test_model = models.ForeignKey(

--- a/tests/test_app/tests/test_admin.py
+++ b/tests/test_app/tests/test_admin.py
@@ -8,7 +8,7 @@ from django.shortcuts import resolve_url
 import reversion
 from reversion.admin import VersionAdmin
 from reversion.models import Version
-from test_app.models import TestModel, TestModelParent, TestModelInline, TestModelGenericInline
+from test_app.models import TestModel, TestModelParent, TestModelInline, TestModelGenericInline, TestModelEscapePK
 from test_app.tests.base import TestBase, LoginMixin
 
 
@@ -187,6 +187,40 @@ class AdminHistoryViewTest(LoginMixin, AdminMixin, TestBase):
             obj.pk,
             Version.objects.get_for_model(TestModelParent).get().pk,
         ))
+
+
+class AdminQuotingTest(LoginMixin, AdminMixin, TestBase):
+
+    def setUp(self):
+        admin.site.register(TestModelEscapePK, VersionAdmin)
+        super(AdminQuotingTest, self).setUp()
+
+    def tearDown(self):
+        admin.site.unregister(TestModelEscapePK)
+        super(AdminQuotingTest, self).tearDown()
+
+    def testHistoryWithQuotedPrimaryKey(self):
+        pk = 'ABC_123'
+        quoted_pk = admin.utils.quote(pk)
+        # test is invalid if quoting does not change anything
+        assert quoted_pk != pk
+
+        with reversion.create_revision():
+            obj = TestModelEscapePK.objects.create(name=pk)
+
+        revision_url = resolve_url(
+            "admin:test_app_testmodelescapepk_revision",
+            quoted_pk,
+            Version.objects.get_for_object(obj).get().pk,
+        )
+        history_url = resolve_url(
+            "admin:test_app_testmodelescapepk_history",
+            quoted_pk
+        )
+        response = self.client.get(history_url)
+        self.assertContains(response, revision_url)
+        response = self.client.get(revision_url)
+        self.assertContains(response, 'value="{}"'.format(pk))
 
 
 class TestModelInlineAdmin(admin.TabularInline):


### PR DESCRIPTION
Issue is as described in #661. Fix is pretty straightforward, just needed to quote/unquote in the right places.

Also adds unit tests that demonstrate issue and verify the fix.