### PR TITLE
avoid comparing Django version each time is_authenticated is called

### DIFF
--- a/reversion/compat.py
+++ b/reversion/compat.py
@@ -24,4 +24,4 @@ def _choose_is_authenticated():
     return django_1_10_and_later
 
 
-is_authenticated = _choose_is_authenticated
+is_authenticated = _choose_is_authenticated()

--- a/reversion/compat.py
+++ b/reversion/compat.py
@@ -11,7 +11,17 @@ def remote_model(field):
     return field.remote_field.model if hasattr(field, 'remote_field') else field.rel.to
 
 
-def is_authenticated(user):
+def _choose_is_authenticated():
+    # Django version does not change during application life so it could
+    # be nicer and faster to know which function to call at import/startup time
     if django.VERSION < (1, 10):
-        return user.is_authenticated()
-    return user.is_authenticated
+        def pre_django_1_10(user):
+            return user.is_authenticated()
+        return pre_django_1_10
+
+    def django_1_10_and_later(user):
+        return user.is_authenticated
+    return django_1_10_and_later
+
+
+is_authenticated = _choose_is_authenticated


### PR DESCRIPTION
According to some simple test with timeit, this change can save 0.06 to 0.08 seconds on each call to is_authenticated