### PR TITLE
set year properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@
 django-reversion changelog
 ==========================
 
-2.0.13 - 23/01/2017
+2.0.13 - 23/01/2018
 -------------------
 
 - Improve performance of ``get_deleted()`` for Oracle (@passuf).


### PR DESCRIPTION
if 2.0.13 is released *after* 2.0.12 and assuming the day and month are right, it must have been released in 2018 not 2017...