### PR TITLE
Fix `ignore_duplicate_revisions` to `ignore_duplicates` in CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -161,7 +161,7 @@ Admin
         class YourVersionAdmin(VersionAdmin):
 
             def reversion_register(self, model, **options):
-                options["ignore_duplicate_revisions"] = True
+                options["ignore_duplicates"] = True
                 super(YourVersionAdmin, self).reversion_register(model, **options)
 
 

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -106,4 +106,4 @@ A subclass of ``django.contrib.ModelAdmin`` providing rollback and recovery.
         The model that will be registered with django-reversion.
 
     ``options``
-        Registeration options, see :ref:`reversion.register() <register>`.
+        Registration options, see :ref:`reversion.register() <register>`.


### PR DESCRIPTION
With the former:

```python-traceback
TypeError: register() got an unexpected keyword argument 'ignore_duplicate_revisions'
```