### PR TITLE
Leave change_message/comment as JSON

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -5,7 +5,6 @@ from django.db import models, transaction, connection
 from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin import options
-from django.contrib.admin.models import LogEntry
 from django.contrib.admin.utils import unquote, quote
 try:
     from django.contrib.contenttypes.admin import GenericInlineModelAdmin
@@ -86,7 +85,7 @@ class VersionAdmin(admin.ModelAdmin):
             # could first call super() and get the change_message from the returned
             # LogEntry.
             if isinstance(change_message, list):
-                set_comment(LogEntry(change_message=json.dumps(change_message)).get_change_message())
+                set_comment(json.dumps(change_message))
             else:
                 set_comment(change_message)
         try:
@@ -97,7 +96,7 @@ class VersionAdmin(admin.ModelAdmin):
     def log_change(self, request, object, message):
         if is_active():
             if isinstance(message, list):
-                set_comment(LogEntry(change_message=json.dumps(message)).get_change_message())
+                set_comment(json.dumps(message))
             else:
                 set_comment(message)
         super(VersionAdmin, self).log_change(request, object, message)

--- a/reversion/models.py
+++ b/reversion/models.py
@@ -7,6 +7,7 @@ try:
 except ImportError:  # Django < 1.9 pragma: no cover
     from django.contrib.contenttypes.generic import GenericForeignKey
 from django.conf import settings
+from django.contrib.admin.models import LogEntry
 from django.core import serializers
 from django.core.serializers.base import DeserializationError
 from django.core.exceptions import ObjectDoesNotExist
@@ -61,6 +62,14 @@ class Revision(models.Model):
         verbose_name=_("comment"),
         help_text="A text comment on this revision.",
     )
+
+    def get_comment(self):
+        try:
+            return LogEntry(change_message=self.comment).get_change_message()
+        except AttributeError:
+            # Django < 1.10
+            # LogEntry dont have `.get_change_message()`
+            return self.comment
 
     def revert(self, delete=False):
         # Group the models by the database of the serialized model.

--- a/reversion/templates/reversion/object_history.html
+++ b/reversion/templates/reversion/object_history.html
@@ -29,7 +29,7 @@
                                         &mdash;
                                     {% endif %}
                                 </td>
-                                <td>{{action.revision.comment|linebreaksbr|default:""}}</td>
+                                <td>{{action.revision.get_comment|linebreaksbr|default:""}}</td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/tests/test_app/tests/base.py
+++ b/tests/test_app/tests/base.py
@@ -51,9 +51,9 @@ class TestBaseMixin(object):
         revision = Version.objects.using(using).get_for_object(objects[0], model_db=model_db).get().revision
         self.assertEqual(revision.user, user)
         if hasattr(comment, 'pattern'):
-            assertRegex(self, revision.comment, comment)
+            assertRegex(self, revision.get_comment(), comment)
         elif comment is not None:  # Allow a wildcard comment.
-            self.assertEqual(revision.comment, comment)
+            self.assertEqual(revision.get_comment(), comment)
         self.assertAlmostEqual(revision.date_created, date_created or timezone.now(), delta=timedelta(seconds=1))
         # Check meta.
         self.assertEqual(revision.testmeta_set.count(), len(meta_names))


### PR DESCRIPTION
Addresses #725 

Accessing `reversion.comment` is now advised via `reversion.get_comment()` 
...should be documented and hinted in the release notes.