### PR TITLE
Add meta param for createinitialrevisions command

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -17,6 +17,7 @@ Creates an initial revision for all registered models in your project. It should
 
     ./manage.py createinitialrevisions
     ./manage.py createinitialrevisions your_app.YourModel --comment="Initial revision."
+    ./manage.py createinitialrevisions your_app.YourModel --meta="{\"your_app.RevisionMeta\": {\"hello\": \"world\"}}"
 
 Run ``./manage.py createinitialrevisions --help`` for more information.
 

--- a/tests/test_app/tests/test_commands.py
+++ b/tests/test_app/tests/test_commands.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from django.core.management import CommandError
 from django.utils import timezone
@@ -79,6 +80,15 @@ class CreateInitialRevisionsCommentTest(TestModelMixin, TestBase):
         obj = TestModel.objects.create()
         self.callCommand("createinitialrevisions", comment="comment v1")
         self.assertSingleRevision((obj,), comment="comment v1")
+
+
+class CreateInitialRevisionsMetaTest(TestModelMixin, TestBase):
+    def testCreateInitialRevisionsComment(self):
+        obj = TestModel.objects.create()
+        meta_name = "meta name"
+        meta = json.dumps({"test_app.TestMeta": {"name": meta_name}})
+        self.callCommand("createinitialrevisions", "--meta", meta)
+        self.assertSingleRevision((obj,), meta_names=(meta_name, ), comment="Initial version.")
 
 
 class DeleteRevisionsTest(TestModelMixin, TestBase):


### PR DESCRIPTION
I needed to add a meta model with every initial revision.

Example:
```
./manage.py createinitialrevisions your_app.YourModel --meta="{\"your_app.RevisionMeta\": {\"hello\": \"world\"}}"
```