### PR TITLE
Add fields to context wrapper

### DIFF
--- a/tests/test_app/tests/test_api.py
+++ b/tests/test_app/tests/test_api.py
@@ -86,9 +86,12 @@ class UnregisterUnregisteredTest(TestBase):
 class CreateRevisionTest(TestModelMixin, TestBase):
 
     def testCreateRevision(self):
-        with reversion.create_revision():
+        meta_name = 'meta name'
+        kwargs = {'name': meta_name}
+        user = User.objects.create()
+        with reversion.create_revision(meta=TestMeta, user=user, comment='hello world!', **kwargs):
             obj = TestModel.objects.create()
-        self.assertSingleRevision((obj,))
+        self.assertSingleRevision((obj,), meta_names=(meta_name, ), user=user, comment='hello world!')
 
     def testCreateRevisionNested(self):
         with reversion.create_revision():


### PR DESCRIPTION
This adds meta, user, and comment support to the `_ContextWrapper`.

I found it nice to build/test my own `create_revision`.

```python
def create_revision_for_obj(user, manage_manually=False, using=None, atomic=True, **kwargs):
    from reversion.models import Revision
    using = using or router.db_for_write(Revision)
    return _ContextWrapper(_create_revision_context, (manage_manually, using, atomic), ObjMeta, user, **kwargs)
```

I then could use it like so (as user and the meta obj were always required):

```python
meta_values = {'hello': 'world'}
with create_revision_for_obj(request.user, **meta_values):
  obj.save()
```

Compared to this:

```python
meta_values = {'hello': 'world'}
with create_revision():
  add_meta(ObjMeta, **meta_values)
  set_user(request.user)
  obj.save()
```

I'm not particularly attached to modifying the actual `create_revision` from the library. But I did add that in case that change to the api was liked. This is more about the changes to `_ContextWrapper` to build your own `create_revision` context managers. I am glad to remove it.
