### PR TITLE
Allow overriding of `_request_creates_revision`.

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -9,14 +9,14 @@ Shortcuts when using django-reversion in views.
 reversion.middleware.RevisionMiddleware
 ---------------------------------------
 
-Wrap the every request that isn't ``GET``, ``HEAD`` or ``OPTIONS`` in a revision block.
+Wrap every request in a revision block.
 
 The request user will also be added to the revision metadata.
 
 To enable ``RevisionMiddleware``, add ``'reversion.middleware.RevisionMiddleware'`` to your ``MIDDLEWARE_CLASSES`` setting. For Django >= 1.10, add it to your ``MIDDLEWARE`` setting.
 
 .. Warning::
-    This will wrap every request that isn't ``GET``, ``HEAD`` or ``OPTIONS`` in a database transaction. For best performance, consider marking individual views instead.
+    This will wrap every request that meets the specified criterion in a database transaction. For best performance, consider marking individual views instead.
 
 
 ``RevisionMiddleware.manage_manually = False``
@@ -32,3 +32,21 @@ To enable ``RevisionMiddleware``, add ``'reversion.middleware.RevisionMiddleware
 ``RevisionMiddleware.atomic = True``
 
     .. include:: /_include/create-revision-atomic.rst
+
+``RevisionMiddleware.request_creates_revision(request)``
+
+    By default, any request that isn't ``GET``, ``HEAD`` or ``OPTIONS`` will be wrapped in a revision block. Override this method if you need to apply a custom rule.
+
+    For example:
+
+    .. code:: python
+
+          from reversion.middleware import RevisionMiddleware
+
+          class BypassRevisionMiddleware(RevisionMiddleware):
+
+              def request_creates_revision(self, request):
+                  # Bypass the revision according to some header
+                  silent = request.META.get("HTTP_X_NOREVISION", "false")
+                  return super().request_creates_revision(request) and \
+                      silent != "true"

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -9,19 +9,23 @@ Shortcuts when using django-reversion in views.
 Decorators
 ----------
 
-``reversion.views.create_revision(manage_manually=False, using=None, atomic=True)``
+``reversion.views.create_revision(manage_manually=False, using=None, atomic=True, request_creates_revision=None)``
 
-    Decorates a view to wrap every request that isn't ``GET``, ``HEAD`` or ``OPTIONS`` in a revision block.
+    Decorates a view to wrap every request in a revision block.
 
     The request user will also be added to the revision metadata. You can set the revision comment by calling :ref:`reversion.set_comment() <set_comment>` within your view.
 
     .. include:: /_include/create-revision-args.rst
 
+    ``request_creates_revision``
+
+        Hook used to decide whether a request should be wrapped in a revision block. If ``None``, it will default to omitting ``GET``, ``HEAD`` and ``OPTIONS`` requests.
+
 
 reversion.views.RevisionMixin
 -----------------------------
 
-Mixin a class-based view to wrap every request that isn't ``GET``, ``HEAD`` or ``OPTIONS`` in a revision block.
+Mixin a class-based view to wrap every request in a revision block.
 
 The request user will also be added to the revision metadata. You can set the revision comment by calling :ref:`reversion.set_comment() <set_comment>` within your view.
 
@@ -43,3 +47,7 @@ The request user will also be added to the revision metadata. You can set the re
 ``RevisionMixin.revision_using = None``
 
     .. include:: /_include/create-revision-using.rst
+
+``RevisionMixin.revision_request_creates_revision(request)``
+
+    By default, any request that isn't ``GET``, ``HEAD`` or ``OPTIONS`` will be wrapped in a revision block. Override this method if you need to apply a custom rule.

--- a/reversion/middleware.py
+++ b/reversion/middleware.py
@@ -20,11 +20,15 @@ class RevisionMiddleware(object):
             self.get_response = create_revision(
                 manage_manually=self.manage_manually,
                 using=self.using,
-                atomic=self.atomic
+                atomic=self.atomic,
+                request_creates_revision=self.request_creates_revision
             )(get_response)
 
+    def request_creates_revision(self, request):
+        return _request_creates_revision(request)
+
     def process_request(self, request):
-        if _request_creates_revision(request):
+        if self.request_creates_revision(request):
             context = create_revision_base(
                 manage_manually=self.manage_manually,
                 using=self.using,

--- a/reversion/views.py
+++ b/reversion/views.py
@@ -19,16 +19,17 @@ def _set_user_from_request(request):
         set_user(request.user)
 
 
-def create_revision(manage_manually=False, using=None, atomic=True):
+def create_revision(manage_manually=False, using=None, atomic=True, request_creates_revision=None):
     """
     View decorator that wraps the request in a revision.
 
     The revision will have it's user set from the request automatically.
     """
+    request_creates_revision = request_creates_revision or _request_creates_revision
     def decorator(func):
         @wraps(func)
         def do_revision_view(request, *args, **kwargs):
-            if _request_creates_revision(request):
+            if request_creates_revision(request):
                 try:
                     with create_revision_base(manage_manually=manage_manually, using=using, atomic=atomic):
                         response = func(request, *args, **kwargs)
@@ -64,5 +65,9 @@ class RevisionMixin(object):
         self.dispatch = create_revision(
             manage_manually=self.revision_manage_manually,
             using=self.revision_using,
-            atomic=self.revision_atomic
+            atomic=self.revision_atomic,
+            request_creates_revision=self.revision_request_creates_revision
         )(self.dispatch)
+
+    def revision_request_creates_revision(self, request):
+        return _request_creates_revision(request)

--- a/reversion/views.py
+++ b/reversion/views.py
@@ -26,6 +26,7 @@ def create_revision(manage_manually=False, using=None, atomic=True, request_crea
     The revision will have it's user set from the request automatically.
     """
     request_creates_revision = request_creates_revision or _request_creates_revision
+
     def decorator(func):
         @wraps(func)
         def do_revision_view(request, *args, **kwargs):

--- a/tests/test_app/tests/test_views.py
+++ b/tests/test_app/tests/test_views.py
@@ -33,6 +33,10 @@ class RevisionMixinTest(TestModelMixin, TestBase):
         self.client.get("/test-app/revision-mixin/")
         self.assertNoRevision()
 
+    def testRevisionMixinCustomPredicate(self):
+        self.client.post("/test-app/revision-mixin/", HTTP_X_NOREVISION="true")
+        self.assertNoRevision()
+
 
 class RevisionMixinUserTest(LoginMixin, TestModelMixin, TestBase):
 

--- a/tests/test_app/views.py
+++ b/tests/test_app/views.py
@@ -20,5 +20,9 @@ def create_revision_view(request):
 
 class RevisionMixinView(RevisionMixin, View):
 
+    def revision_request_creates_revision(self, request):
+        silent = request.META.get("HTTP_X_NOREVISION", "false") == "true"
+        return super(RevisionMixinView, self).revision_request_creates_revision(request) and not silent
+
     def dispatch(self, request):
         return save_obj_view(request)


### PR DESCRIPTION
Through the custom methods `RevisionMixin.revision_request_creates_revision` and `RevisionMiddleware.request_creates_revision`, as well as an additional optional parameter for the view decorator `create_revision`, the user can provide a predicate that may extend or override the default "reject if GET, HEAD or OPTIONS" criterion.

I'm aware that this behaviour can be achieved by not using the mixin / middleware / view decorator and manually annotating blocks of code. However, I believe this would simplify things by centralizing any additional, all-covering criteria.