### PR TITLE
Add extra fields to create_revision interface

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,6 +146,22 @@ Reverting a :ref:`Revision` will restore any serialized model instances that hav
     assert obj.name == "version 2"
 
 
+Custom create revision context managers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Create a `create_revision` context manager that is specific to your application and models.
+
+.. code:: python
+
+    def create_revision_for_your_obj(user, status):
+        # Assuming YourObjMeta has a field called 'status' that needs to be
+        # set on every revision
+        return create_revision(user=User, meta=YourObjMeta, status=status)
+
+    with create_revision_for_your_obj(request.user, 'draft'):
+        obj.save()
+
+
 .. _registration-api:
 
 Registration API
@@ -216,7 +232,7 @@ Registration API
 Revision API
 ------------
 
-``reversion.create_revision(manage_manually=False, using=None, atomic=True)``
+``reversion.create_revision(manage_manually=False, using=None, atomic=True, user=None, comment=None, meta=None, **kwargs)``
 
     Marks a block of code as a *revision block*. Can also be used as a decorator.
 

--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -316,6 +316,7 @@ def create_revision(manage_manually=False, using=None, atomic=True, user=None, c
         **kwargs
     )
 
+
 class _ContextWrapper(object):
 
     def __init__(self, func, args, **kwargs):

--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -277,7 +277,7 @@ def _dummy_context():
 
 
 @contextmanager
-def _create_revision_context(manage_manually, using, atomic):
+def _create_revision_context(manage_manually, using, atomic, user, comment, meta, **kwargs):
     _push_frame(manage_manually, using)
     try:
         context = transaction.atomic(using=using) if atomic else _dummy_context()
@@ -285,6 +285,12 @@ def _create_revision_context(manage_manually, using, atomic):
             yield
             # Only save for a db if that's the last stack frame for that db.
             if not any(using in frame.db_versions for frame in _local.stack[:-1]):
+                if user:
+                    set_user(user)
+                if comment:
+                    set_comment(comment)
+                if meta:
+                    add_meta(meta, **kwargs)
                 current_frame = _current_frame()
                 _save_revision(
                     versions=current_frame.db_versions[using].values(),
@@ -298,18 +304,25 @@ def _create_revision_context(manage_manually, using, atomic):
         _pop_frame()
 
 
-def create_revision(manage_manually=False, using=None, atomic=True):
+def create_revision(manage_manually=False, using=None, atomic=True, user=None, comment=None, meta=None, **kwargs):
     from reversion.models import Revision
     using = using or router.db_for_write(Revision)
-    return _ContextWrapper(_create_revision_context, (manage_manually, using, atomic))
-
+    return _ContextWrapper(
+        _create_revision_context,
+        (manage_manually, using, atomic),
+        user=user,
+        comment=comment,
+        meta=meta,
+        **kwargs
+    )
 
 class _ContextWrapper(object):
 
-    def __init__(self, func, args):
+    def __init__(self, func, args, **kwargs):
         self._func = func
         self._args = args
-        self._context = func(*args)
+        self._kwargs = kwargs
+        self._context = func(*args, **kwargs)
 
     def __enter__(self):
         return self._context.__enter__()
@@ -320,7 +333,7 @@ class _ContextWrapper(object):
     def __call__(self, func):
         @wraps(func)
         def do_revision_context(*args, **kwargs):
-            with self._func(*self._args):
+            with self._func(*self._args, **self._kwargs):
                 return func(*args, **kwargs)
         return do_revision_context
 


### PR DESCRIPTION
This is a continuation of https://github.com/etianen/django-reversion/pull/731

> Unfortunately, I've had to revert this pull request.
> Extra fields should be added to create_revision(), not _create_revision_context(), which is a private  API.

If I understood this correctly, I added the the feature to the `create_revision` as that is the public api. I did also have to modify `_create_revision_context()` in order to allow the `create_revision` update to work, as per your original suggestion:

> Nice idea!
> 
> I think that this should be implemented inside the _create_revision_context function, since then the calls to set_meta, set_comment etc only need to be implemeted in one place.

Also added documentation.