### PR TITLE
Fixed TypeError exception when accessing m2m_data attributes

### DIFF
--- a/reversion/models.py
+++ b/reversion/models.py
@@ -270,7 +270,7 @@ class Version(models.Model):
             field = model._meta.get_field(field_name)
             if isinstance(field, models.ManyToManyField):
                 # M2M fields with a custom through are not stored in m2m_data, but as a separate model.
-                if field.attname in object_version.m2m_data:
+                if object_version.m2m_data and field.attname in object_version.m2m_data:
                     field_dict[field.attname] = object_version.m2m_data[field.attname]
             else:
                 field_dict[field.attname] = getattr(obj, field.attname)


### PR DESCRIPTION
Even if you have a M2M relation to `django.contrib.auth.models.User` or you call `django.contrib.auth.get_user_model()` you can’t access `Version.field_dict` attributes.

In my case I had a Model like this:
```
@reversion.register()
class MyModel(models.Model):
    users = models.ManyToMany(get_user_model(), related_name='my_models', blank=True)
    
    # More fields
    (...)
```

When I was working on a low-level codebase around Version objects, I found that calling `version_obj.field_dict[field_name]` doesn't works if a M2M was present pointing to User. Any other M2M relation works smoothly. 

https://github.com/etianen/django-reversion/blob/3d05eed4c6e242bf7f0e8bd4726918bb3a771764/reversion/models.py#L269-L274

The problem is that `m2m_data` is not always available and it raises a `TypeError: argument of type 'NoneType' is not iterable`.

This PR fixes that problem :) 