### PR TITLE
Update safe_subquery method to use exists as it is much much faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ services:
   - postgresql
   - mysql
 install:
-  - pip install flake8 coverage mock sphinx django$DJANGO psycopg2 mysqlclient -e .
+  # mysqlclient 1.4 is not compatible with Django 1.11
+  - pip install flake8 coverage mock sphinx django$DJANGO psycopg2 mysqlclient==1.3.14 -e .
 before_script:
   - mysql -e 'create database test_project'
   - psql -c 'create database test_project;' -U postgres;


### PR DESCRIPTION
The test suite itself runs in 4 instead of 7 seconds on my local machine.

The NOT IN that was previously used grows exponentially with the data size, whereas the NOT EXISTS is almost flat. The code is already more than 1000x faster when running a createinitialrevisions with 50000 objects in PostgreSQL.

Only constraint, it is Django 1.11+ only, but so is already at least the test suite, isn't it?