### PR TITLE
tests: make tests requiring an external database skippable

### DIFF
--- a/tests/test_app/tests/base.py
+++ b/tests/test_app/tests/base.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import skipIf
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
@@ -107,3 +108,7 @@ class LoginMixin(UserMixin):
     def setUp(self):
         super(LoginMixin, self).setUp()
         self.client.login(username="test", password="password")
+
+
+def requiresDatabase(db_name):
+    return skipIf(db_name not in settings.DATABASES, "Database {} not available".format(db_name))

--- a/tests/test_app/tests/test_api.py
+++ b/tests/test_app/tests/test_api.py
@@ -5,7 +5,7 @@ from django.db.transaction import get_connection
 from django.utils import timezone
 import reversion
 from test_app.models import TestModel, TestModelRelated, TestModelThrough, TestModelParent, TestMeta
-from test_app.tests.base import TestBase, TestBaseTransaction, TestModelMixin, UserMixin
+from test_app.tests.base import TestBase, TestBaseTransaction, TestModelMixin, UserMixin, requiresDatabase
 
 try:
     from unittest.mock import MagicMock
@@ -159,6 +159,8 @@ class CreateRevisionManageManuallyTest(TestModelMixin, TestBase):
 
 class CreateRevisionDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("mysql")
+    @requiresDatabase("postgres")
     def testCreateRevisionMultiDb(self):
         with reversion.create_revision(using="mysql"), reversion.create_revision(using="postgres"):
             obj = TestModel.objects.create()
@@ -319,6 +321,8 @@ class AddMetaTest(TestModelMixin, TestBase):
         with self.assertRaises(reversion.RevisionManagementError):
             reversion.add_meta(TestMeta, name="meta v1")
 
+    @requiresDatabase("mysql")
+    @requiresDatabase("postgres")
     def testAddMetaMultDb(self):
         with reversion.create_revision(using="mysql"), reversion.create_revision(using="postgres"):
             obj = TestModel.objects.create()

--- a/tests/test_app/tests/test_commands.py
+++ b/tests/test_app/tests/test_commands.py
@@ -4,7 +4,7 @@ from django.core.management import CommandError
 from django.utils import timezone
 import reversion
 from test_app.models import TestModel
-from test_app.tests.base import TestBase, TestModelMixin
+from test_app.tests.base import TestBase, TestModelMixin, requiresDatabase
 
 
 class CreateInitialRevisionsTest(TestModelMixin, TestBase):
@@ -53,12 +53,14 @@ class CreateInitialRevisionsAppLabelTest(TestModelMixin, TestBase):
 
 class CreateInitialRevisionsDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testCreateInitialRevisionsDb(self):
         obj = TestModel.objects.create()
         self.callCommand("createinitialrevisions", using="postgres")
         self.assertNoRevision()
         self.assertSingleRevision((obj,), comment="Initial version.", using="postgres")
 
+    @requiresDatabase("mysql")
     def testCreateInitialRevisionsDbMySql(self):
         obj = TestModel.objects.create()
         self.callCommand("createinitialrevisions", using="mysql")
@@ -68,6 +70,7 @@ class CreateInitialRevisionsDbTest(TestModelMixin, TestBase):
 
 class CreateInitialRevisionsModelDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testCreateInitialRevisionsModelDb(self):
         obj = TestModel.objects.db_manager("postgres").create()
         self.callCommand("createinitialrevisions", model_db="postgres")
@@ -135,18 +138,21 @@ class DeleteRevisionsAppLabelTest(TestModelMixin, TestBase):
 
 class DeleteRevisionsDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testDeleteRevisionsDb(self):
         with reversion.create_revision(using="postgres"):
             TestModel.objects.create()
         self.callCommand("deleterevisions", using="postgres")
         self.assertNoRevision(using="postgres")
 
+    @requiresDatabase("mysql")
     def testDeleteRevisionsDbMySql(self):
         with reversion.create_revision(using="mysql"):
             TestModel.objects.create()
         self.callCommand("deleterevisions", using="mysql")
         self.assertNoRevision(using="mysql")
 
+    @requiresDatabase("postgres")
     def testDeleteRevisionsDbNoMatch(self):
         with reversion.create_revision():
             obj = TestModel.objects.create()
@@ -156,6 +162,7 @@ class DeleteRevisionsDbTest(TestModelMixin, TestBase):
 
 class DeleteRevisionsModelDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testDeleteRevisionsModelDb(self):
         with reversion.create_revision():
             TestModel.objects.db_manager("postgres").create()

--- a/tests/test_app/tests/test_models.py
+++ b/tests/test_app/tests/test_models.py
@@ -5,7 +5,7 @@ from test_app.models import (
     TestModel, TestModelRelated, TestModelParent, TestModelInline,
     TestModelNestedInline,
 )
-from test_app.tests.base import TestBase, TestModelMixin, TestModelParentMixin
+from test_app.tests.base import TestBase, TestModelMixin, TestModelParentMixin, requiresDatabase
 
 
 class GetForModelTest(TestModelMixin, TestBase):
@@ -18,11 +18,13 @@ class GetForModelTest(TestModelMixin, TestBase):
 
 class GetForModelDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testGetForModelDb(self):
         with reversion.create_revision(using="postgres"):
             obj = TestModel.objects.create()
         self.assertEqual(Version.objects.using("postgres").get_for_model(obj.__class__).count(), 1)
 
+    @requiresDatabase("mysql")
     def testGetForModelDbMySql(self):
         with reversion.create_revision(using="mysql"):
             obj = TestModel.objects.create()
@@ -60,12 +62,14 @@ class GetForObjectTest(TestModelMixin, TestBase):
 
 class GetForObjectDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testGetForObjectDb(self):
         with reversion.create_revision(using="postgres"):
             obj = TestModel.objects.create()
         self.assertEqual(Version.objects.get_for_object(obj).count(), 0)
         self.assertEqual(Version.objects.using("postgres").get_for_object(obj).count(), 1)
 
+    @requiresDatabase("mysql")
     def testGetForObjectDbMySql(self):
         with reversion.create_revision(using="mysql"):
             obj = TestModel.objects.create()
@@ -75,6 +79,7 @@ class GetForObjectDbTest(TestModelMixin, TestBase):
 
 class GetForObjectModelDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testGetForObjectModelDb(self):
         with reversion.create_revision():
             obj = TestModel.objects.db_manager("postgres").create()
@@ -131,6 +136,7 @@ class GetForObjectReferenceTest(TestModelMixin, TestBase):
 
 class GetForObjectReferenceDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testGetForObjectReferenceModelDb(self):
         with reversion.create_revision(using="postgres"):
             obj = TestModel.objects.create()
@@ -140,12 +146,14 @@ class GetForObjectReferenceDbTest(TestModelMixin, TestBase):
 
 class GetForObjectReferenceModelDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testGetForObjectReferenceModelDb(self):
         with reversion.create_revision():
             obj = TestModel.objects.db_manager("postgres").create()
         self.assertEqual(Version.objects.get_for_object_reference(TestModel, obj.pk).count(), 0)
         self.assertEqual(Version.objects.get_for_object_reference(TestModel, obj.pk, model_db="postgres").count(), 1)
 
+    @requiresDatabase("mysql")
     def testGetForObjectReferenceModelDbMySql(self):
         with reversion.create_revision():
             obj = TestModel.objects.db_manager("mysql").create()
@@ -180,6 +188,7 @@ class GetDeletedTest(TestModelMixin, TestBase):
         self.assertEqual(Version.objects.get_deleted(TestModel)[0].object_id, force_text(pk_2))
         self.assertEqual(Version.objects.get_deleted(TestModel)[1].object_id, force_text(pk_1))
 
+    @requiresDatabase("postgres")
     def testGetDeletedPostgres(self):
         with reversion.create_revision(using="postgres"):
             obj = TestModel.objects.using("postgres").create()
@@ -188,6 +197,7 @@ class GetDeletedTest(TestModelMixin, TestBase):
         obj.delete()
         self.assertEqual(Version.objects.using("postgres").get_deleted(TestModel, model_db="postgres").count(), 1)
 
+    @requiresDatabase("mysql")
     def testGetDeletedMySQL(self):
         with reversion.create_revision(using="mysql"):
             obj = TestModel.objects.using("mysql").create()
@@ -199,6 +209,7 @@ class GetDeletedTest(TestModelMixin, TestBase):
 
 class GetDeletedDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testGetDeletedDb(self):
         with reversion.create_revision(using="postgres"):
             obj = TestModel.objects.create()
@@ -206,6 +217,7 @@ class GetDeletedDbTest(TestModelMixin, TestBase):
         self.assertEqual(Version.objects.get_deleted(TestModel).count(), 0)
         self.assertEqual(Version.objects.using("postgres").get_deleted(TestModel).count(), 1)
 
+    @requiresDatabase("mysql")
     def testGetDeletedDbMySql(self):
         with reversion.create_revision(using="mysql"):
             obj = TestModel.objects.create()
@@ -216,6 +228,7 @@ class GetDeletedDbTest(TestModelMixin, TestBase):
 
 class GetDeletedModelDbTest(TestModelMixin, TestBase):
 
+    @requiresDatabase("postgres")
     def testGetDeletedModelDb(self):
         with reversion.create_revision():
             obj = TestModel.objects.db_manager("postgres").create()

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -81,19 +81,21 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     },
-    "postgres": {
+}
+if not os.environ.get("DJANGO_REVERSION_TESTS_NO_POSTGRES", None):
+    DATABASES["postgres"] = {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "NAME": os.environ.get("DJANGO_DATABASE_NAME_POSTGRES", "test_project"),
         "USER": os.environ.get("DJANGO_DATABASE_USER_POSTGRES", getpass.getuser()),
         "PASSWORD": os.environ.get("DJANGO_DATABASE_PASSWORD_POSTGRES", ""),
-    },
-    "mysql": {
+    }
+if not os.environ.get("DJANGO_REVERSION_TESTS_NO_MYSQL", None):
+    DATABASES["mysql"] = {
         "ENGINE": "django.db.backends.mysql",
         "NAME": os.environ.get("DJANGO_DATABASE_NAME_MYSQL", "test_project"),
         "USER": os.environ.get("DJANGO_DATABASE_USER_MYSQL", getpass.getuser()),
         "PASSWORD": os.environ.get("DJANGO_DATABASE_PASSWORD_MYSQL", ""),
-    },
-}
+    }
 
 
 # Password validation


### PR DESCRIPTION
Here's my little stab at a solution for #773 - seems to work well for me on python 3.7 and 2.7.

Do with what you will.