### PR TITLE
fix version view for model inherited from other model

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -170,7 +170,7 @@ class VersionAdmin(admin.ModelAdmin):
         try:
             with transaction.atomic(using=version.db):
                 # Revert the revision.
-                version.revision.revert(delete=True)
+                version.revision.revert(delete=False)
                 # Run the normal changeform view.
                 with self.create_revision(request):
                     response = self.changeform_view(request, quote(version.object_id), request.path, extra_context)


### PR DESCRIPTION
Now when one has:

```
model A(models.Model):
   ....

model B(A):
   ....
````

And try to view version for model B, exception occurs:

"AttributeError: 'HttpResponseRedirect' object has no attribute 'render'" `line 196, in _reversion_revisionform_view`

That's because `current_revision` contains both A and B instances while `old_revision` contains only B instance. Then instance A is deleted but because of model inheritance and one to one field, instance B is also deleted from db.
