### PR TITLE
Use exists subquery to find deleted model instance pks

### DIFF
--- a/reversion/models.py
+++ b/reversion/models.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers.base import DeserializationError
 from django.db import IntegrityError, connections, models, router, transaction
 from django.db.models.deletion import Collector
-from django.db.models.expressions import RawSQL
+from django.db.models.functions import Cast
 from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext
@@ -114,12 +114,6 @@ class Revision(models.Model):
         ordering = ("-pk",)
 
 
-class SubquerySQL(RawSQL):
-
-    def as_sql(self, compiler, connection):
-        return self.sql, self.params
-
-
 class VersionQuerySet(models.QuerySet):
 
     def get_for_model(self, model, model_db=None):
@@ -139,47 +133,22 @@ class VersionQuerySet(models.QuerySet):
         return self.get_for_object_reference(obj.__class__, obj.pk, model_db=model_db)
 
     def get_deleted(self, model, model_db=None):
-        # Try to do a faster JOIN.
         model_db = model_db or router.db_for_write(model)
-        connection = connections[self.db]
-        if self.db == model_db and connection.vendor in ("sqlite", "postgresql", "oracle"):
-            content_type = _get_content_type(model, self.db)
-            subquery = SubquerySQL(
-                """
-                SELECT MAX(V.{id})
-                FROM {version} V
-                LEFT JOIN {model} ON V.{object_id} = CAST({model}.{model_id} as {str})
-                WHERE
-                    V.{db} = %s AND
-                    V.{content_type_id} = %s AND
-                    {model}.{model_id} IS NULL
-                GROUP BY V.{object_id}
-                """.format(
-                    id=connection.ops.quote_name("id"),
-                    version=connection.ops.quote_name(Version._meta.db_table),
-                    model=connection.ops.quote_name(model._meta.db_table),
-                    model_id=connection.ops.quote_name(model._meta.pk.db_column or model._meta.pk.attname),
-                    object_id=connection.ops.quote_name("object_id"),
-                    str=Version._meta.get_field("object_id").db_type(connection),
-                    db=connection.ops.quote_name("db"),
-                    content_type_id=connection.ops.quote_name("content_type_id"),
-                ),
-                (model_db, content_type.id),
-                output_field=Version._meta.pk,
-            )
-        else:
-            # We have to use a slow subquery.
-            subquery = self.get_for_model(model, model_db=model_db).exclude(
-                object_id__in=list(
-                    model._default_manager.using(model_db).values_list("pk", flat=True).order_by().iterator()
-                ),
-            ).values_list("object_id").annotate(
-                latest_pk=models.Max("pk")
-            ).order_by().values_list("latest_pk", flat=True)
-        # Perform the subquery.
-        return self.filter(
-            pk__in=subquery,
+        model_qs = (
+            model._default_manager
+            .using(model_db)
+            .annotate(_pk_to_object_id=Cast("pk", Version._meta.get_field("object_id")))
+            .filter(_pk_to_object_id=models.OuterRef("object_id"))
         )
+        subquery = (
+            self.get_for_model(model, model_db=model_db)
+            .annotate(pk_not_exists=~models.Exists(model_qs))
+            .filter(pk_not_exists=True)
+            .values("object_id")
+            .annotate(latest_pk=models.Max("pk"))
+            .values("latest_pk")
+        )
+        return self.filter(pk__in=subquery)
 
     def get_unique(self):
         last_key = None


### PR DESCRIPTION
This is an idea that may improve the performance of `get_deleted` for some of the users in #748.

The changes shift the subquery on the model on `get_deleted` to use the built-in `Exists` (only django versions 1.11 and up are listed as supported as of now, and `Exists` was added in this version). The subquery should work across supported backends, the test suite passes, and I've used locally in MySQL and Postgres successfully.

As far as performance goes, things get a bit tricky, and I've been able to look into query times only in Postgres at the moment. But, in Postgres, I've experienced performance changes similar similar to the following when running `get_deleted` on the entire `Version` queryset:

* For smaller models (in my testing, models with 10,000 or fewer instances), the original query takes 20% of the time of the new query (though on reasonable hardware for models of this size we are talking only a few milliseconds)
* For larger models (in my testing, models with 100,000 or more instances), I've found that the new query takes 20% of the time of the original query (from roughly 10 seconds to 2 seconds in a relatively large model)

But there is another use case in which I've found more significant performance improvements (see jedie/django-reversion-compare#95). In the linked issue, the performance issues are from the following line (https://github.com/jedie/django-reversion-compare/blob/0bfe214e40933e38a5e5a94f3c6d0f56de9051be/reversion_compare/compare.py#L206):

```python
    deleted = list(Version.objects.filter(revision=old_revision).get_deleted(related_model))
```

Here, the original query still must iterate over the pks the related model, but using `Exists` results in a _significant_ performance improvement (in a model with a few million instances and many deletions, the query went from about 50 seconds to 1.5 milliseconds).

That being said, there are a couple of issues:

1. The performance improvement for larger models and filtered querysets may not be worth the cost for other cases
2. Should work with django's natively supported database backends, but performance may vary