### PR TITLE
Emphasise that clicking the link doesn't revert

### DIFF
--- a/reversion/templates/reversion/object_history.html
+++ b/reversion/templates/reversion/object_history.html
@@ -5,7 +5,7 @@
 {% block content %}
     <div id="content-main">
 
-        <p>{% blocktrans %}Choose a date from the list below to revert to a previous version of this object.{% endblocktrans %}</p>
+        <p>{% blocktrans %}Choose a date from the list below to view a previous version of this object and to revert to it.{% endblocktrans %}</p>
 
         <div class="module">
             {% if action_list %}

--- a/reversion/templates/reversion/object_history.html
+++ b/reversion/templates/reversion/object_history.html
@@ -5,7 +5,7 @@
 {% block content %}
     <div id="content-main">
 
-        <p>{% blocktrans %}Choose a date from the list below to view a previous version of this object and to revert to it.{% endblocktrans %}</p>
+        <p>{% blocktrans %}Choose a date from the list below to view a previous version of this object, and optionally revert to it.{% endblocktrans %}</p> 
 
         <div class="module">
             {% if action_list %}


### PR DESCRIPTION
A small change, it would be quicker to view the diff than to explain it.

As a new user, when I first saw the sentence, I thought that clicking the link immediately reverted to that version, when in actuality, it displays the version first.