### PR TITLE
Replace force_text with force_str

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.utils.text import capfirst
 from django.utils.timezone import template_localtime
 from django.utils.translation import ugettext as _
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.formats import localize
 from reversion.errors import RevertError
 from reversion.models import Version
@@ -176,7 +176,7 @@ class VersionAdmin(admin.ModelAdmin):
                         raise _RollBackRevisionView(response)  # Raise exception to undo the transaction and revision.
         except RevertError as ex:
             opts = self.model._meta
-            messages.error(request, force_text(ex))
+            messages.error(request, force_str(ex))
             return redirect("{}:{}_{}_changelist".format(self.admin_site.name, opts.app_label, opts.model_name))
         except _RollBackRevisionView as ex:
             return ex.response
@@ -242,7 +242,7 @@ class VersionAdmin(admin.ModelAdmin):
             opts=opts,
             app_label=opts.app_label,
             module_name=capfirst(opts.verbose_name),
-            title=_("Recover deleted %(name)s") % {"name": force_text(opts.verbose_name_plural)},
+            title=_("Recover deleted %(name)s") % {"name": force_str(opts.verbose_name_plural)},
             deleted=deleted,
         )
         context.update(extra_context or {})

--- a/reversion/models.py
+++ b/reversion/models.py
@@ -11,7 +11,7 @@ from django.core.serializers.base import DeserializationError
 from django.db import IntegrityError, connections, models, router, transaction
 from django.db.models.deletion import Collector
 from django.db.models.functions import Cast
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
@@ -104,7 +104,7 @@ class Revision(models.Model):
                 _safe_revert(versions)
 
     def __str__(self):
-        return ", ".join(force_text(version) for version in self.version_set.all())
+        return ", ".join(force_str(version) for version in self.version_set.all())
 
     class Meta:
         app_label = "reversion"
@@ -226,7 +226,7 @@ class Version(models.Model):
     @cached_property
     def _object_version(self):
         data = self.serialized_data
-        data = force_text(data.encode("utf8"))
+        data = force_str(data.encode("utf8"))
         try:
             return list(serializers.deserialize(self.format, data, ignorenonexistent=True))[0]
         except DeserializationError:

--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction, router
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_save, m2m_changed
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils import timezone
 from reversion.errors import RevisionManagementError, RegistrationError
 from reversion.signals import pre_revision_commit, post_revision_commit
@@ -173,7 +173,7 @@ def _add_to_revision(obj, using, model_db, explicit):
         return
     version_options = _get_options(obj.__class__)
     content_type = _get_content_type(obj.__class__, using)
-    object_id = force_text(obj.pk)
+    object_id = force_str(obj.pk)
     version_key = (content_type, object_id)
     # If the obj is already in the revision, stop now.
     db_versions = _current_frame().db_versions
@@ -191,7 +191,7 @@ def _add_to_revision(obj, using, model_db, explicit):
             (obj,),
             fields=version_options.fields,
         ),
-        object_repr=force_text(obj),
+        object_repr=force_str(obj),
     )
     # If the version is a duplicate, stop now.
     if version_options.ignore_duplicates and explicit:
@@ -223,7 +223,7 @@ def _save_revision(versions, user=None, comment="", meta=(), date_created=None, 
     model_db_existing_pks = {
         model: {
             db: frozenset(map(
-                force_text,
+                force_str,
                 model._base_manager.using(db).filter(pk__in=pks).values_list("pk", flat=True),
             ))
             for db, pks in db_pks.items()


### PR DESCRIPTION
The former is deprecated in Django 3.0 and has been an alias for force_str
since Django 2.0:
https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text

Use of force_text raises deprecation warnings on Django 3.0.