### PR TITLE
Adjust setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ version control for model instances.
 Requirements
 ============
 
-- Python 3.5 or later
+- Python 3.6 or later
 - Django 1.11 or later
 
 Features

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length=120
 exclude=venv,migrations

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,18 @@ try:
 except ImportError:
     cmdclass = {}
 
+
+def read(filepath):
+    with open(filepath, "r", encoding="utf-8") as f:
+        return f.read()
+
+
 setup(
     name="django-reversion",
     version='.'.join(str(x) for x in __version__),
     license="BSD",
     description="An extension to the Django web framework that provides version control for model instances.",
+    long_description=read('README.rst'),
     author="Dave Hall",
     author_email="dave@etianen.com",
     url="http://github.com/etianen/django-reversion",

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     install_requires=[
         "django>=1.11",
     ],
+    python_requires='>=3.6',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
- Enforce Python 3.6+
- Make wheels non-universal (Python 2 support is missing for universal)
- Add a long description for https://pypi.org/project/django-reversion/