### PR TITLE
Update Changelog to add upgrade note

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,16 @@ django-reversion changelog
 ------------------
 
 - Removed squashed migrations, as they subtly messed up the Django migrations framework (@etianen).
-
+  
+  To upgrade to ``>= 3.0.2`` from ``< 3.0.1``:
+  
+  .. code::
+  
+    pip install django-reversion==3.0.1
+    python manage.py migrate reversion
+    pip install --upgrade django-reversion
+    python manage.py migrate reversion
+ 
 
 3.0.1 - 2018-10-23
 ------------------


### PR DESCRIPTION
When upgrading from old versions it's necessary to incrementally upgrade at version `3.0.1`, run migrations, and then proceed.

[See here for more info](https://github.com/etianen/django-reversion/issues/822#issuecomment-621361180)