### PR TITLE
Removed `providing_args` argument from signals because of django 4.0 …

### DIFF
--- a/reversion/signals.py
+++ b/reversion/signals.py
@@ -1,10 +1,5 @@
 from django.dispatch.dispatcher import Signal
 
-
-_signal_args = [
-    "revision",
-    "versions",
-]
-
-pre_revision_commit = Signal(providing_args=_signal_args)
-post_revision_commit = Signal(providing_args=_signal_args)
+# Signal arguments: revision and versions
+pre_revision_commit = Signal()
+post_revision_commit = Signal()


### PR DESCRIPTION
…deprecation. Also removed `_signal_args` var from signals.py

Fixes https://github.com/etianen/django-reversion/issues/840