### PR TITLE
Run tests against Django 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - DJANGO_DATABASE_USER_POSTGRES=postgres
     - DJANGO_DATABASE_USER_MYSQL=travis
   matrix:
+    - DJANGO='>=3.1,<3.2'
     - DJANGO='>=3.0,<3.1'
     - DJANGO='>=2.2,<3.0'
     - DJANGO='>=2.1,<2.2'
@@ -44,7 +45,7 @@ deploy:
     secure: XW4/9HiChbPJSJe4d/MRcO+ViPGhW1iQ8kVi814KJh7mCxOAKijpW5hfdc9oSKB6d8iYB3OzZ7naIUU9GMce40bpeTgPDLVBLCSYKRNLuVoJdh+Q6ItGUiFf8kAJz5jgopG80QnCpLA9JvYxKVJ4amfYWWm204eQmIEnRRAd+Jk=
   on:
     tags: true
-    condition: $DJANGO = '>=3.0,<3.1'
+    condition: $DJANGO = '>=3.1,<3.2'
     python: 3.6
     repo: etianen/django-reversion
   distributions: sdist bdist_wheel

--- a/tests/test_app/tests/test_api.py
+++ b/tests/test_app/tests/test_api.py
@@ -173,6 +173,7 @@ class CreateRevisionManageManuallyTest(TestModelMixin, TestBase):
 
 
 class CreateRevisionDbTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testCreateRevisionMultiDb(self):
         with reversion.create_revision(using="mysql"), reversion.create_revision(using="postgres"):
@@ -323,6 +324,7 @@ class GetDateCreatedTest(TestBase):
 
 
 class AddMetaTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testAddMeta(self):
         with reversion.create_revision():

--- a/tests/test_app/tests/test_commands.py
+++ b/tests/test_app/tests/test_commands.py
@@ -52,6 +52,7 @@ class CreateInitialRevisionsAppLabelTest(TestModelMixin, TestBase):
 
 
 class CreateInitialRevisionsDbTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testCreateInitialRevisionsDb(self):
         obj = TestModel.objects.create()
@@ -67,6 +68,7 @@ class CreateInitialRevisionsDbTest(TestModelMixin, TestBase):
 
 
 class CreateInitialRevisionsModelDbTest(TestModelMixin, TestBase):
+    databases = {"default", "postgres"}
 
     def testCreateInitialRevisionsModelDb(self):
         obj = TestModel.objects.db_manager("postgres").create()
@@ -134,6 +136,7 @@ class DeleteRevisionsAppLabelTest(TestModelMixin, TestBase):
 
 
 class DeleteRevisionsDbTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testDeleteRevisionsDb(self):
         with reversion.create_revision(using="postgres"):
@@ -155,6 +158,7 @@ class DeleteRevisionsDbTest(TestModelMixin, TestBase):
 
 
 class DeleteRevisionsModelDbTest(TestModelMixin, TestBase):
+    databases = {"default", "postgres"}
 
     def testDeleteRevisionsModelDb(self):
         with reversion.create_revision():

--- a/tests/test_app/tests/test_models.py
+++ b/tests/test_app/tests/test_models.py
@@ -18,6 +18,7 @@ class GetForModelTest(TestModelMixin, TestBase):
 
 
 class GetForModelDbTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testGetForModelDb(self):
         with reversion.create_revision(using="postgres"):
@@ -60,6 +61,7 @@ class GetForObjectTest(TestModelMixin, TestBase):
 
 
 class GetForObjectDbTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testGetForObjectDb(self):
         with reversion.create_revision(using="postgres"):
@@ -75,6 +77,7 @@ class GetForObjectDbTest(TestModelMixin, TestBase):
 
 
 class GetForObjectModelDbTest(TestModelMixin, TestBase):
+    databases = {"default", "postgres"}
 
     def testGetForObjectModelDb(self):
         with reversion.create_revision():
@@ -131,6 +134,7 @@ class GetForObjectReferenceTest(TestModelMixin, TestBase):
 
 
 class GetForObjectReferenceDbTest(TestModelMixin, TestBase):
+    databases = {"default", "postgres"}
 
     def testGetForObjectReferenceModelDb(self):
         with reversion.create_revision(using="postgres"):
@@ -140,6 +144,7 @@ class GetForObjectReferenceDbTest(TestModelMixin, TestBase):
 
 
 class GetForObjectReferenceModelDbTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testGetForObjectReferenceModelDb(self):
         with reversion.create_revision():
@@ -155,6 +160,7 @@ class GetForObjectReferenceModelDbTest(TestModelMixin, TestBase):
 
 
 class GetDeletedTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testGetDeleted(self):
         with reversion.create_revision():
@@ -199,6 +205,7 @@ class GetDeletedTest(TestModelMixin, TestBase):
 
 
 class GetDeletedDbTest(TestModelMixin, TestBase):
+    databases = {"default", "mysql", "postgres"}
 
     def testGetDeletedDb(self):
         with reversion.create_revision(using="postgres"):
@@ -216,6 +223,7 @@ class GetDeletedDbTest(TestModelMixin, TestBase):
 
 
 class GetDeletedModelDbTest(TestModelMixin, TestBase):
+    databases = {"default", "postgres"}
 
     def testGetDeletedModelDb(self):
         with reversion.create_revision():


### PR DESCRIPTION
- `databases` was introduced in Django 2.2, see https://docs.djangoproject.com/en/dev/releases/2.2/#tests
- `multi_db` was deprecated at the same time, see https://docs.djangoproject.com/en/dev/releases/2.2/#id2