### PR TITLE
Create apps.py

### DIFF
--- a/reversion/apps.py
+++ b/reversion/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 
+
 class ReversionConfig(AppConfig):
     name = 'reversion'
-    default_auto_field = 'django.db.models.BigAutoField'
+    default_auto_field = 'django.db.models.AutoField'

--- a/reversion/apps.py
+++ b/reversion/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class ReversionConfig(AppConfig):
+    name = 'reversion'
+    default_auto_field = 'django.db.models.BigAutoField'


### PR DESCRIPTION
Solves #873.

By adding an AppConfig, one can set the `default_auto_field`. The other parameters of the AppConfig are chosen so the behaviour for other installations remains unchanged.