### PR TITLE
Python 3.10: run automated tests for Django 4.0.x against Python 3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
       DJANGO_DATABASE_PASSWORD_MYSQL: root
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
         django-version:
           - '>=4.0a1,<4.1'
           - '>=3.2,<4.0'
@@ -54,7 +54,19 @@ jobs:
           - python-version: 3.6
             django-version: '>=4.0a1,<4.1'
           - python-version: 3.7
-            django-version: '>=4.0a1,<4.1'   
+            django-version: '>=4.0a1,<4.1'
+          - python-version: '3.10'
+            django-version: '>=3.2,<4.0'
+          - python-version: '3.10'
+            django-version: '>=3.1,<3.2'
+          - python-version: '3.10'
+            django-version: '>=3.0,<3.1'
+          - python-version: '3.10'
+            django-version: '>=2.2,<3.0'
+          - python-version: '3.10'
+            django-version: '>=2.1,<2.2'
+          - python-version: '3.10'
+            django-version: '>=2.0,<2.1'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         "Framework :: Django",
     ]
 )


### PR DESCRIPTION
[Django >4.0.x supports Python 3.10](https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django) so would be good to test against it. All the tests passed locally (Django==4.0.0b1, Python 3.10.0) with postgres but didn't test mysql.

Thought it was better to make it not very DRY and explicitly _exclude_ the older Django versions then having a single _include_ for 3.10 and forgetting to add another include when 4.1.x is released.