### PR TITLE
Improved performance of `createinitialrevisions` management command on postgres databases

### DIFF
--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -2,7 +2,7 @@ import json
 
 from django.apps import apps
 from django.core.management import CommandError
-from django.db import reset_queries, transaction, router
+from django.db import connections, reset_queries, transaction, router
 from reversion.models import Revision, Version, _safe_subquery
 from reversion.management.commands import BaseRevisionCommand
 from reversion.revisions import create_revision, set_comment, add_to_revision, add_meta
@@ -50,8 +50,11 @@ class Command(BaseRevisionCommand):
             except LookupError:
                 raise CommandError("Unknown model: {}".format(label))
         meta_values = meta.values()
-        # Create revisions.
+        # Determine if we should use queryset.iterator()
         using = using or router.db_for_write(Revision)
+        server_side_cursors = not connections[using].settings_dict.get('DISABLE_SERVER_SIDE_CURSORS')
+        use_iterator = connections[using].vendor in ("postgresql",) and server_side_cursors
+        # Create revisions.
         with transaction.atomic(using=using):
             for model in self.get_models(options):
                 # Check all models for empty revisions.
@@ -70,28 +73,48 @@ class Command(BaseRevisionCommand):
                     ),
                     "object_id",
                 )
+                live_objs = live_objs.order_by()
                 # Save all the versions.
-                ids = list(live_objs.values_list("pk", flat=True).order_by())
-                total = len(ids)
-                for i in range(0, total, batch_size):
-                    chunked_ids = ids[i:i+batch_size]
-                    objects = live_objs.in_bulk(chunked_ids)
-                    for obj in objects.values():
-                        with create_revision(using=using):
-                            if meta:
-                                for model, values in zip(meta_models, meta_values):
-                                    add_meta(model, **values)
-                            set_comment(comment)
-                            add_to_revision(obj, model_db=model_db)
-                        created_count += 1
-                    reset_queries()
-                    if verbosity >= 2:
-                        self.stdout.write("- Created {created_count} / {total}".format(
-                            created_count=created_count,
-                            total=total,
-                        ))
+                if use_iterator:
+                    total = live_objs.count()
+                    if total:
+                        for obj in live_objs.iterator(batch_size):
+                            self.create_revision(obj, using, meta, meta_models, meta_values, comment, model_db)
+                            created_count += 1
+                            # Print out a message every batch_size if feeling extra verbose
+                            if not created_count % batch_size:
+                                self.batch_complete(verbosity, created_count, total)
+                else:
+                    # Save all the versions.
+                    ids = list(live_objs.values_list("pk", flat=True))
+                    total = len(ids)
+                    for i in range(0, total, batch_size):
+                        chunked_ids = ids[i:i+batch_size]
+                        objects = live_objs.in_bulk(chunked_ids)
+                        for obj in objects.values():
+                            self.create_revision(obj, using, meta, meta_models, meta_values, comment, model_db)
+                            created_count += 1
+                        # Print out a message every batch_size if feeling extra verbose
+                        self.batch_complete(verbosity, created_count, total)
+
                 # Print out a message, if feeling verbose.
                 if verbosity >= 1:
                     self.stdout.write("- Created {total} / {total}".format(
                         total=total,
                     ))
+
+    def create_revision(self, obj, using, meta, meta_models, meta_values, comment, model_db):
+        with create_revision(using=using):
+            if meta:
+                for model, values in zip(meta_models, meta_values):
+                    add_meta(model, **values)
+            set_comment(comment)
+            add_to_revision(obj, model_db=model_db)
+
+    def batch_complete(self, verbosity, created_count, total):
+        reset_queries()
+        if verbosity >= 2:
+            self.stdout.write("- Created {created_count} / {total}".format(
+                created_count=created_count,
+                total=total,
+            ))


### PR DESCRIPTION
Rather than retrieving the list of PKs that needs revisions created for, and then pulling out the actual objects in separate queries using `in_bulk`, we drop it down to a single `count()` query (to get the total number) and an `iterator()` query. This improves the performance (and possibly memory usage) on postgres databases when server side cursors are enabled (which they are by default on postgres databases). For databases where server side cursors are not enabled, we revert to the original code as `iterator()` is memory intensive (at the database driver level, see Django documentation on `iterator()` for further details).

My local tests suggest that this provides a speed-up of a factor of 2. Would be good if someone else could verify to confirm that's not just an artefact of my set-up though!