### PR TITLE
Fix admin detail view in multi-database environment

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from django.db import models, transaction, connection
+from django.db import models, transaction, connections
 from django.contrib import admin, messages
 from django.contrib.admin import options
 from django.contrib.admin.utils import unquote, quote
@@ -163,7 +163,7 @@ class VersionAdmin(admin.ModelAdmin):
 
     def _reversion_revisionform_view(self, request, version, template_name, extra_context=None):
         # Check that database transactions are supported.
-        if not connection.features.uses_savepoints:
+        if not connections[version.db].features.uses_savepoints:
             raise ImproperlyConfigured("Cannot use VersionAdmin with a database that does not support savepoints.")
         # Run the view.
         try:


### PR DESCRIPTION
There's a bug with false-positive trigger of **Cannot use VersionAdmin with a database that does not support savepoints.** exception on the admin page of a versioned model. It can be reproduced with Django configuration with multiple databases:

```
# default DB backend is dummy
DATABASES = {
    'default': {},
    'db1': {
        'ENGINE': 'django.db.backends.postgresql',
        ...
    },
    'db2': {
        'ENGINE': 'django.db.backends.postgresql',
        ...
    }
}
```

Thus, `connection.features.uses_savepoints` is irrelevant and should be replaced with `connections[version.db].features.uses_savepoints`.