### PR TITLE
Add support of Django 4.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,28 +43,16 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
         django-version:
-          - '>=4.0a1,<4.1'
+          - '>=4.1,<4.2'
+          - '>=4.0,<4.1'
           - '>=3.2,<4.0'
-          - '>=3.1,<3.2'
-          - '>=3.0,<3.1'
-          - '>=2.2,<3.0'
-          - '>=2.1,<2.2'
-          - '>=2.0,<2.1'
         exclude:
           - python-version: 3.7
-            django-version: '>=4.0a1,<4.1'
+            django-version: '>=4.1,<4.2'
+          - python-version: 3.7
+            django-version: '>=4.0,<4.1'
           - python-version: '3.10'
             django-version: '>=3.2,<4.0'
-          - python-version: '3.10'
-            django-version: '>=3.1,<3.2'
-          - python-version: '3.10'
-            django-version: '>=3.0,<3.1'
-          - python-version: '3.10'
-            django-version: '>=2.2,<3.0'
-          - python-version: '3.10'
-            django-version: '>=2.1,<2.2'
-          - python-version: '3.10'
-            django-version: '>=2.0,<2.1'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # django-reversion documentation build configuration file, created by
 # sphinx-quickstart on Thu Jun  2 08:41:36 2016.

--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -53,8 +53,8 @@ class VersionAdmin(admin.ModelAdmin):
     def _reversion_get_template_list(self, template_name):
         opts = self.model._meta
         return (
-            "reversion/%s/%s/%s" % (opts.app_label, opts.object_name.lower(), template_name),
-            "reversion/%s/%s" % (opts.app_label, template_name),
+            f"reversion/{opts.app_label}/{opts.object_name.lower()}/{template_name}",
+            f"reversion/{opts.app_label}/{template_name}",
             "reversion/%s" % template_name,
         )
 
@@ -185,7 +185,7 @@ class VersionAdmin(admin.ModelAdmin):
         except (RevertError, models.ProtectedError) as ex:
             opts = self.model._meta
             messages.error(request, force_str(ex))
-            return redirect("{}:{}_{}_changelist".format(self.admin_site.name, opts.app_label, opts.model_name))
+            return redirect(f"{self.admin_site.name}:{opts.app_label}_{opts.model_name}_changelist")
         except _RollBackRevisionView as ex:
             return ex.response
         return response
@@ -275,7 +275,7 @@ class VersionAdmin(admin.ModelAdmin):
             {
                 "revision": version.revision,
                 "url": reverse(
-                    "%s:%s_%s_revision" % (self.admin_site.name, opts.app_label, opts.model_name),
+                    f"{self.admin_site.name}:{opts.app_label}_{opts.model_name}_revision",
                     args=(quote(version.object_id), version.id)
                 ),
             }

--- a/reversion/management/commands/__init__.py
+++ b/reversion/management/commands/__init__.py
@@ -43,7 +43,7 @@ class BaseRevisionCommand(BaseCommand):
                     try:
                         model = apps.get_model(label)
                     except LookupError:
-                        raise CommandError("Unknown model: {}".format(label))
+                        raise CommandError(f"Unknown model: {label}")
                     selected_models.add(model)
                 else:
                     # This is just an app - no model qualifier.
@@ -51,7 +51,7 @@ class BaseRevisionCommand(BaseCommand):
                     try:
                         app = apps.get_app_config(app_label)
                     except LookupError:
-                        raise CommandError("Unknown app: {}".format(app_label))
+                        raise CommandError(f"Unknown app: {app_label}")
                     selected_models.update(app.get_models())
         for model in selected_models:
             if is_registered(model):

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -48,7 +48,7 @@ class Command(BaseRevisionCommand):
                 model = apps.get_model(label)
                 meta_models.append(model)
             except LookupError:
-                raise CommandError("Unknown model: {}".format(label))
+                raise CommandError(f"Unknown model: {label}")
         meta_values = meta.values()
         # Determine if we should use queryset.iterator()
         using = using or router.db_for_write(Revision)

--- a/reversion/migrations/0001_squashed_0004_auto_20160611_1202.py
+++ b/reversion/migrations/0001_squashed_0004_auto_20160611_1202.py
@@ -44,6 +44,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='version',
-            unique_together=set([('db', 'content_type', 'object_id', 'revision')]),
+            unique_together={('db', 'content_type', 'object_id', 'revision')},
         ),
     ]

--- a/reversion/models.py
+++ b/reversion/models.py
@@ -366,25 +366,25 @@ def _safe_subquery(method, left_query, left_field_name, right_subquery, right_fi
         )
     ):
         return getattr(left_query, method)(**{
-            "{}__in".format(left_field_name): list(right_subquery.iterator()),
+            f"{left_field_name}__in": list(right_subquery.iterator()),
         })
     else:
         # If the left hand side is not a text field, we need to cast it.
         if not isinstance(left_field, (models.CharField, models.TextField)):
-            left_field_name_str = "{}_str".format(left_field_name)
+            left_field_name_str = f"{left_field_name}_str"
             left_query = left_query.annotate(**{
                 left_field_name_str: _Str(left_field_name),
             })
             left_field_name = left_field_name_str
         # If the right hand side is not a text field, we need to cast it.
         if not isinstance(right_field, (models.CharField, models.TextField)):
-            right_field_name_str = "{}_str".format(right_field_name)
+            right_field_name_str = f"{right_field_name}_str"
             right_subquery = right_subquery.annotate(**{
                 right_field_name_str: _Str(right_field_name),
             }).values_list(right_field_name_str, flat=True)
             right_field_name = right_field_name_str
         # Use Exists if running on the same DB, it is much much faster
-        exist_annotation_name = "{}_annotation_str".format(right_subquery.model._meta.db_table)
+        exist_annotation_name = f"{right_subquery.model._meta.db_table}_annotation_str"
         right_subquery = right_subquery.filter(**{right_field_name: models.OuterRef(left_field_name)})
         left_query = left_query.annotate(**{exist_annotation_name: models.Exists(right_subquery)})
         return getattr(left_query, method)(**{exist_annotation_name: True})

--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -142,8 +142,7 @@ def _follow_relations(obj):
         if isinstance(follow_obj, models.Model):
             yield follow_obj
         elif isinstance(follow_obj, (models.Manager, QuerySet)):
-            for follow_obj_instance in follow_obj.all():
-                yield follow_obj_instance
+            yield from follow_obj.all()
         elif follow_obj is not None:
             raise RegistrationError("{name}.{follow_name} should be a Model or QuerySet".format(
                 name=obj.__class__.__name__,
@@ -299,7 +298,7 @@ def create_revision(manage_manually=False, using=None, atomic=True):
     return _ContextWrapper(_create_revision_context, (manage_manually, using, atomic))
 
 
-class _ContextWrapper(object):
+class _ContextWrapper:
 
     def __init__(self, func, args):
         self._func = func

--- a/reversion/views.py
+++ b/reversion/views.py
@@ -34,7 +34,7 @@ def create_revision(manage_manually=False, using=None, atomic=True, request_crea
     return decorator
 
 
-class RevisionMixin(object):
+class RevisionMixin:
 
     """
     A class-based view mixin that wraps the request in a revision.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 def read(filepath):
-    with open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8") as f:
         return f.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "reversion": ["locale/*/LC_MESSAGES/django.*", "templates/reversion/*.html"]},
     cmdclass=cmdclass,
     install_requires=[
-        "django>=2.0",
+        "django>=3.2",
     ],
     python_requires='>=3.7',
     classifiers=[

--- a/tests/test_app/tests/base.py
+++ b/tests/test_app/tests/base.py
@@ -19,7 +19,7 @@ from test_app.models import TestModel, TestModelParent
 
 class TestBaseMixin:
 
-    multi_db = True
+    databases = "__all__"
 
     def reloadUrls(self):
         reload(import_module(settings.ROOT_URLCONF))

--- a/tests/test_app/tests/base.py
+++ b/tests/test_app/tests/base.py
@@ -17,7 +17,7 @@ from test_app.models import TestModel, TestModelParent
 
 # Test helpers.
 
-class TestBaseMixin(object):
+class TestBaseMixin:
 
     multi_db = True
 
@@ -76,7 +76,7 @@ class TestBaseTransaction(TestBaseMixin, TransactionTestCase):
     pass
 
 
-class TestModelMixin(object):
+class TestModelMixin:
 
     def setUp(self):
         super().setUp()

--- a/tests/test_app/tests/test_admin.py
+++ b/tests/test_app/tests/test_admin.py
@@ -218,7 +218,7 @@ class AdminQuotingTest(LoginMixin, AdminMixin, TestBase):
         response = self.client.get(history_url)
         self.assertContains(response, revision_url)
         response = self.client.get(revision_url)
-        self.assertContains(response, 'value="{}"'.format(pk))
+        self.assertContains(response, f'value="{pk}"')
 
 
 class TestModelInlineAdmin(admin.TabularInline):

--- a/tests/test_app/tests/test_api.py
+++ b/tests/test_app/tests/test_api.py
@@ -32,7 +32,7 @@ class IsRegisterUnregisteredTest(TestBase):
 class GetRegisteredModelsTest(TestModelMixin, TestBase):
 
     def testGetRegisteredModels(self):
-        self.assertEqual(set(reversion.get_registered_models()), set((TestModel,)))
+        self.assertEqual(set(reversion.get_registered_models()), {TestModel})
 
 
 class RegisterTest(TestBase):

--- a/tests/test_app/tests/test_models.py
+++ b/tests/test_app/tests/test_models.py
@@ -317,7 +317,7 @@ class M2MTest(TestModelMixin, TestBase):
             obj.related.add(v1)
             obj.related.add(v2)
         version = Version.objects.get_for_object(obj).first()
-        self.assertEqual(set(version.field_dict["related"]), set((v1.pk, v2.pk,)))
+        self.assertEqual(set(version.field_dict["related"]), {v1.pk, v2.pk})
 
 
 class RevertTest(TestModelMixin, TestBase):

--- a/tests/test_app/views.py
+++ b/tests/test_app/views.py
@@ -23,7 +23,7 @@ def create_revision_view(request):
 class RevisionMixinView(RevisionMixin, View):
 
     def revision_request_creates_revision(self, request):
-        silent = request.META.get("HTTP_X_NOREVISION", "false") == "true"
+        silent = request.headers.get('X-Norevision', "false") == "true"
         return super().revision_request_creates_revision(request) and not silent
 
     def dispatch(self, request):

--- a/tests/test_project/urls.py
+++ b/tests/test_project/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include
+from django.urls import include
 from django.urls import path
 from django.contrib import admin
 


### PR DESCRIPTION
Hi ! This PR introduces support of Django 4.1

Also removes support of deprecated Django versions (all of those below 3.2 LTS).

I've run both pyupgrade and django-upgrade and isolated these changes in separate commits. Feel free to squash them.