### PR TITLE
`_safe_revert`: Add a `logging` statement for `IntegrityError`

### DIFF
--- a/reversion/models.py
+++ b/reversion/models.py
@@ -33,7 +33,7 @@ def _safe_revert(versions):
             with transaction.atomic(using=version.db):
                 version.revert()
         except (IntegrityError, ObjectDoesNotExist):
-            logger.exception('Could not revert to {version}')
+            logger.warning('Could not revert to {version}', exc_info=True)
             unreverted_versions.append(version)
     if len(unreverted_versions) == len(versions):
         raise RevertError(gettext("Could not save %(object_repr)s version - missing dependency.") % {

--- a/reversion/models.py
+++ b/reversion/models.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from itertools import chain, groupby
+import logging
 
 import django
 from django.apps import apps
@@ -22,6 +23,9 @@ from reversion.revisions import (_follow_relations_recursive,
                                  _get_content_type, _get_options)
 
 
+logger = logging.getLogger(__name__)
+
+
 def _safe_revert(versions):
     unreverted_versions = []
     for version in versions:
@@ -29,6 +33,7 @@ def _safe_revert(versions):
             with transaction.atomic(using=version.db):
                 version.revert()
         except (IntegrityError, ObjectDoesNotExist):
+            logger.exception('Could not revert to {version}')
             unreverted_versions.append(version)
     if len(unreverted_versions) == len(versions):
         raise RevertError(gettext("Could not save %(object_repr)s version - missing dependency.") % {


### PR DESCRIPTION
_Fixes #750_

This will be welcomed by users explicitly declaring `fields` with [`@reversion.register`](https://github.com/etianen/django-reversion/blob/v5.0.2/reversion/revisions.py#L363) ([docs](https://django-reversion.readthedocs.io/en/release-1.10.2/api.html#saving-a-subset-of-fields)).

Add a [`logging`](https://docs.python.org/3/library/logging.html) message for [`IntegrityError`](https://docs.djangoproject.com/en/4.1/ref/exceptions/#django.db.IntegrityError)

[`logging.traceback()`](https://docs.python.org/3/library/logging.html#logging.exception) offered the perfect level of detail to see which field(s) it's stuck on.

<details>

<summary>Example logging message</summary>

```
Traceback (most recent call last):
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.NotNullViolation: null value in column "weight" of relation "page" violates not-null constraint
DETAIL:  Failing row contains (null, null, 2022-09-21 18:17:24.021+00, 2022-09-21 18:17:24.021+00, 9387e659-c5a4-45d0-ab93-03b0ec354c4b, Page title, Content, <p>..., null, t, f, 13e682c5-a8d4-4aba-a715-16876094d4e1, null, null, null, null, null, null, bb603cb4-5ca3-48db-b7ec-3977db70f784, null).


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "~/projects/python/django-reversion/reversion/models.py", line 34, in _safe_revert
    version.revert()
  File "~/projects/python/django-reversion/reversion/models.py", line 327, in revert
    self._object_version.save(using=self.db)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/core/serializers/base.py", line 223, in save
    models.Model.save_base(self.object, using=using, raw=True, **kwargs)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/models/base.py", line 776, in save_base
    updated = self._save_table(
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/models/base.py", line 858, in _save_table
    updated = self._do_update(base_qs, using, pk_val, values, update_fields,
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/models/base.py", line 912, in _do_update
    return filtered._update(values) > 0
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/models/query.py", line 802, in _update
    return query.get_compiler(self.db).execute_sql(CURSOR)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/models/sql/compiler.py", line 1559, in execute_sql
    cursor = super().execute_sql(result_type)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/models/sql/compiler.py", line 1175, in execute_sql
    cursor.execute(sql, params)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/backends/utils.py", line 98, in execute
    return super().execute(sql, params)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/backends/utils.py", line 79, in _execute
    with self.db.wrap_database_errors:
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "~/projects/django-site/.venv/lib/python3.10/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: null value in column "weight" of relation "page" violates not-null constraint
DETAIL:  Failing row contains (null, null, 2022-09-21 18:17:24.021+00, 2022-09-21 18:17:24.021+00, 9387e659-c5a4-45d0-ab93-03b0ec354c4b, Page title, Content, <p>..., null, t, f, 13e682c5-a8d4-4aba-a715-16876094d4e1, null, null, null, null, null, null, bb603cb4-5ca3-48db-b7ec-3977db70f784, null).
```

</details>