### PR TITLE
Update Django version required in README to 3.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Requirements
 ============
 
 - Python 3.7 or later
-- Django 2.0 or later
+- Django 3.2 or later
 
 Features
 ========


### PR DESCRIPTION
The minimum version of Django was updated in https://github.com/etianen/django-reversion/pull/917 but the readme still showed 2.0 as supported.