### PR TITLE
Introduce default format setting.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -174,6 +174,8 @@ Registration API
     ``format="json"``
         The name of a Django serialization format to use when saving the model instance.
 
+        Default format for all models could be set via ``REVERSION_DEFAULT_FORMAT`` variable in your settings module.
+
     ``for_concrete_model=True``
         If ``True`` proxy models will be saved under the same content type as their concrete model. If ``False``, proxy models will be saved under their own content type, effectively giving proxy models their own distinct history.
 

--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -5,6 +5,7 @@ from functools import wraps
 from django.apps import apps
 from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist
+from django.conf import settings
 from django.db import models, transaction, router
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_save, m2m_changed
@@ -366,7 +367,7 @@ def _get_senders_and_signals(model):
         yield m2m_model, m2m_changed, _m2m_changed_receiver
 
 
-def register(model=None, fields=None, exclude=(), follow=(), format="json",
+def register(model=None, fields=None, exclude=(), follow=(), format=None,
              for_concrete_model=True, ignore_duplicates=False, use_natural_foreign_keys=False):
     def register(model):
         # Prevent multiple registration.
@@ -388,7 +389,7 @@ def register(model=None, fields=None, exclude=(), follow=(), format="json",
                 if field_name not in exclude
             ),
             follow=tuple(follow),
-            format=format,
+            format=format or getattr(settings, "REVERSION_DEFAULT_FORMAT", "json"),
             for_concrete_model=for_concrete_model,
             ignore_duplicates=ignore_duplicates,
             use_natural_foreign_keys=use_natural_foreign_keys,

--- a/reversion/revisions.py
+++ b/reversion/revisions.py
@@ -5,7 +5,6 @@ from functools import wraps
 from django.apps import apps
 from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist
-from django.conf import settings
 from django.db import models, transaction, router
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_save, m2m_changed
@@ -13,6 +12,7 @@ from django.utils.encoding import force_str
 from django.utils import timezone
 from reversion.errors import RevisionManagementError, RegistrationError
 from reversion.signals import pre_revision_commit, post_revision_commit
+from reversion.settings import app_settings
 
 
 _VersionOptions = namedtuple("VersionOptions", (
@@ -389,7 +389,7 @@ def register(model=None, fields=None, exclude=(), follow=(), format=None,
                 if field_name not in exclude
             ),
             follow=tuple(follow),
-            format=format or getattr(settings, "REVERSION_DEFAULT_FORMAT", "json"),
+            format=format or app_settings.DEFAULT_FORMAT,
             for_concrete_model=for_concrete_model,
             ignore_duplicates=ignore_duplicates,
             use_natural_foreign_keys=use_natural_foreign_keys,

--- a/reversion/settings.py
+++ b/reversion/settings.py
@@ -1,0 +1,51 @@
+"""
+Settings for `Reversion` are all namespaced in the REVERSION setting.
+
+For example your project's `settings.py` file might look like this:
+
+REVERSION = {
+    'DEFAULT_FORMAT': 'xml',
+}
+
+This module provides the `app_setting` object, that is used to access
+Reversion settings, checking for user settings first, then falling
+back to the defaults.
+
+"""
+from django.conf import settings
+
+
+DEFAULTS = {
+    "DEFAULT_FORMAT": "json",
+}
+
+
+class AppSettings:
+    """
+    A settings object that allows Reversion settings to be
+    accessed as properties. For example:
+
+        from reversion.settings import app_settings
+        print(app_settings.DEFAULT_FORMAT)
+
+    Note: This is an internal class that is only compatible with
+    settings namespaced under the REVERSION name. It is not
+    intended to be used by 3rd-party apps, and test helpers like
+    `override_settings` may not work as expected.
+
+    """
+
+    def __getattr__(self, attribute):
+        if attribute not in DEFAULTS:
+            raise AttributeError("Invalid Reversion setting: '%s'" % attr)
+
+        try:
+            user_settings = getattr(settings, 'REVERSION', {})
+            value = user_settings[attribute]
+        except KeyError:
+            value = DEFAULTS[attribute]
+
+        return value
+
+
+app_settings = AppSettings()

--- a/reversion/settings.py
+++ b/reversion/settings.py
@@ -17,6 +17,9 @@ from django.conf import settings
 
 DEFAULTS = {
     "DEFAULT_FORMAT": "json",
+    "DEFAULT_FOR_CONCRETE_MODEL": True,
+    "DEFAULT_IGNORE_DUPLICATES": False,
+    "DEFAULT_USE_NATURAL_FOREIGN_KEYS": False,
 }
 
 
@@ -37,7 +40,7 @@ class AppSettings:
 
     def __getattr__(self, attribute):
         if attribute not in DEFAULTS:
-            raise AttributeError("Invalid Reversion setting: '%s'" % attr)
+            raise AttributeError("Invalid Reversion setting: '%s'" % attribute)
 
         try:
             user_settings = getattr(settings, 'REVERSION', {})

--- a/tests/test_app/tests/test_models.py
+++ b/tests/test_app/tests/test_models.py
@@ -462,7 +462,7 @@ class TransactionRollbackTest(TestBase):
                 pass
 
 
-@override_settings(REVERSION_DEFAULT_FORMAT="xml")
+@override_settings(REVERSION={"DEFAULT_FORMAT": "xml"})
 class DefaultFormatSettingTest(TestBase):
 
     def setUp(self):


### PR DESCRIPTION
Good evening,

The reason I'm interested in this pull request to be landed:

We frequently use model field from third-party library which can't be handled by core Django serializers.

I wrote custom serializer, not big deal. But now I need to mention custom format name in every call to `register` decorator.

Would be nice to set it once and forget about it :smile: 

Best regards,
Josiah.