### PR TITLE
perf: Fixes N+1 queries while rendering the recover_list.html template

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -245,7 +245,9 @@ class VersionAdmin(admin.ModelAdmin):
             raise PermissionDenied
         model = self.model
         opts = model._meta
-        deleted = self._reversion_order_version_queryset(Version.objects.get_deleted(self.model))
+        deleted = self._reversion_order_version_queryset(
+            Version.objects.get_deleted(self.model).select_related("revision")
+        )
         # Set the app name.
         request.current_app = self.admin_site.name
         # Get the rest of the context.


### PR DESCRIPTION
While running a project with django-reversion and Sentry we found out there's one template that makes a query to the DB on every iteration. This PR fixes that

https://docs.sentry.io/product/issues/issue-details/performance-issues/n-one-queries/
https://docs.djangoproject.com/en/5.0/ref/models/querysets/#django.db.models.query.QuerySet.select_related