### PR TITLE
Switch call from removed is_hidden method to hidden property

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -116,7 +116,7 @@ class VersionAdmin(admin.ModelAdmin):
                     ):
                         fk_name = field.name
                         break
-            if fk_name and not inline_model._meta.get_field(fk_name).remote_field.is_hidden():
+            if fk_name and not inline_model._meta.get_field(fk_name).remote_field.hidden:
                 field = inline_model._meta.get_field(fk_name)
                 accessor = field.remote_field.get_accessor_name()
                 follow_field = accessor


### PR DESCRIPTION
`ForeignObjectRel.is_hidden()` was removed in
https://github.com/django/django/pull/17862 in favor of the `hidden` property of the same class. This change will be released in django 5.1. In previous versions of django, the `hidden` property called the `is_hidden()` method, so there should not be changes in behavior for older versions.