### PR TITLE
Speed up deletions

### DIFF
--- a/reversion/management/commands/deleterevisions.py
+++ b/reversion/management/commands/deleterevisions.py
@@ -73,7 +73,7 @@ class Command(BaseRevisionCommand):
                         ).values_list("revision_id", flat=True)[:keep].iterator())
                 # Add to revision query.
                 revision_query |= models.Q(
-                    pk__in=model_query.order_by().values_list("revision_id", flat=True)
+                    pk__in=model_query.order_by().values_list("revision_id", flat=True).distinct()
                 )
                 # If we have at least one model, then we can delete.
                 can_delete = True
@@ -91,4 +91,6 @@ class Command(BaseRevisionCommand):
                 self.stdout.write("Deleting {total} revisions...".format(
                     total=revisions_to_delete.count(),
                 ))
+            qs = Version.objects.filter(revision__in=revisions_to_delete)
+            qs._raw_delete(qs.db)
             revisions_to_delete.delete()


### PR DESCRIPTION
There are two performance issues I encountered with the 'deleterevisions' command:
- The query to obtain the revisions that need to be deleted was very slow. This is part because a given revision may have many object versions attached to it, so the revision_id list ends up being large and populated with largely similar values. Thus adding ```.distinst()``` to the query speeds up the process enourmously
- Calling ```revisions_to_delete.delete()``` has the side effect of loading all versions and calling any signals. In my case, this consumed a lot of memory and blew up. I propose to pre-delete all versions using ```._raw_delete()``` method. I considered object caches, but since the revisions are deleted with ```.delete()```, any revisions objects will be invalidated, so at worst, any ```Version``` objects in the cache will remain inaccessible and get invalidated slowly over time.