### PR TITLE
Fix 500 error that occurred when no fields changed

### DIFF
--- a/reversion/admin.py
+++ b/reversion/admin.py
@@ -87,13 +87,13 @@ class VersionAdmin(admin.ModelAdmin):
     def log_addition(self, request, object, message):
         change_message = message or _("Initial version.")
         entry = super().log_addition(request, object, change_message)
-        if is_active():
+        if entry and is_active():
             set_comment(entry.get_change_message())
         return entry
 
     def log_change(self, request, object, message):
         entry = super().log_change(request, object, message)
-        if is_active():
+        if entry and is_active():
             set_comment(entry.get_change_message())
         return entry
 


### PR DESCRIPTION
Using Django 6.0 and django-reversion 6.1.0, I was getting a 500 error when saving a model where no fields had changed. This PR fixes this bug.